### PR TITLE
Update expiry date in setup script

### DIFF
--- a/Labfiles/custom-doc-intelligence/setup.sh
+++ b/Labfiles/custom-doc-intelligence/setup.sh
@@ -4,7 +4,7 @@
 subscription_id="YOUR_SUBSCRIPTION_ID"
 resource_group="YOUR_RESOURCE_GROUP"
 location="YOUR_LOCATION_NAME"
-expiry_date="2026-01-01T00:00:00Z"
+expiry_date="2028-01-01T00:00:00Z"
 
 # Get random numbers to create unique resource names
 unique_id=$((1 + RANDOM % 99999))


### PR DESCRIPTION

# Module: 00
## Lab/Demo: 4

Changes proposed in this pull request:
SAS token expiration date is in the past now, bumped it by another 2 years until Jan 1, 2028

-
-
-