### PR TITLE
LAB03: Fix comment references in document intelligence model instructions

### DIFF
--- a/Instructions/Labs/03-prebuilt-doc-intelligence-model.md
+++ b/Instructions/Labs/03-prebuilt-doc-intelligence-model.md
@@ -125,7 +125,7 @@ Now you're ready to use the SDK to evaluate the pdf file.
 
     The file is opened in a code editor.
 
-1. In the code file, find the comment **Import the required libraries** and add the following code:
+1. In the code file, find the comment **Add references** and add the following code:
 
     ```python
    # Add references
@@ -151,7 +151,7 @@ Now you're ready to use the SDK to evaluate the pdf file.
    )
     ```
 
-1. Find the comment **Display invoice information to the user**and add the following code:
+1. Find the comment **Display invoice information to the user** and add the following code:
 
     ```python
    # Display invoice information to the user


### PR DESCRIPTION
# Module: 01
## Lab/Demo: 03

Changes proposed in this pull request:

This pull request updates the instructions in the `03-prebuilt-doc-intelligence-model.md` lab guide to clarify the step for adding library imports in the code file.

Documentation improvements:

* Updated the step instruction to direct users to find the comment **Add references** instead of **Import the required libraries** when adding import statements in the code file. (`Instructions/Labs/03-prebuilt-doc-intelligence-model.md`)