### PR TITLE
LAB 04: Update link and instructions for accessing Document Intelligence Studio

### DIFF
--- a/Instructions/Labs/04-custom-doc-intelligence-model.md
+++ b/Instructions/Labs/04-custom-doc-intelligence-model.md
@@ -105,7 +105,8 @@ You'll use the sample forms such as this one to train a test a model:
 
 Now you will train the model using the files uploaded to the storage account.
 
-1. Open a new browser tab, and navigate to the Document Intelligence Studio at `https://documentintelligence.ai.azure.com/studio`. 
+1. Open a new browser tab, and navigate to the Content Understanding Studio at `https://contentunderstanding.ai.azure.com/`. 
+1. Click on the button **Start with Document Intelligence** to enter in the Document Intelligence Studio.
 1. Scroll down to the **Custom models** section and select the **Custom extraction model** tile.
 1. If prompted, sign in with your Azure credentials.
 1. If you are asked which Azure AI Document Intelligence resource to use, select the subscription and resource name you used when you created the Azure AI Document Intelligence resource.


### PR DESCRIPTION
# Module: 04
## Lab/Demo: 04

Changes proposed in this pull request:

This pull request updates the instructions for accessing the Azure AI Document Intelligence Studio to reflect changes in the platform's navigation. The most important change is updating the URL and adding a step to enter the Document Intelligence Studio.

Platform navigation update:

* Changed the instructions to direct users to the Content Understanding Studio at `https://contentunderstanding.ai.azure.com/` instead of the previous Document Intelligence Studio URL, and added a step to click **Start with Document Intelligence** to enter the Document Intelligence Studio. The previous link in the instructions now is redirected automatically to Content Understanding Studio.