### PR TITLE
Backfill missing lab metadata (10 files)

### DIFF
--- a/Instructions/Exercises/01-content-understanding.md
+++ b/Instructions/Exercises/01-content-understanding.md
@@ -1,7 +1,13 @@
 ---
 lab:
-    title: 'Extract information from multimodal content'
-    description: 'Use Azure Content Understanding to extract insights from documents, images, audio recordings, and videos.'
+  title: Extract information from multimodal content
+  description: Use Azure Content Understanding to extract insights from documents, images, audio recordings, and videos.
+  duration: 40 minutes
+  level: 100
+  islab: true
+  primarytopics:
+    - Azure
+    - Azure Content Understanding
 ---
 
 # Extract information from multimodal content

--- a/Instructions/Exercises/02-content-understanding-api.md
+++ b/Instructions/Exercises/02-content-understanding-api.md
@@ -1,7 +1,13 @@
 ---
 lab:
-    title: 'Develop a Content Understanding client application'
-    description: 'Use the Azure Content Understanding Python SDK to create and use analyzers programmatically.'
+  title: Develop a Content Understanding client application
+  description: Use the Azure Content Understanding Python SDK to create and use analyzers programmatically.
+  duration: 30 minutes
+  level: 300
+  islab: true
+  primarytopics:
+    - Azure
+    - Azure Content Understanding
 ---
 
 # Develop a Content Understanding client application

--- a/Instructions/Exercises/03-document-intelligence.md
+++ b/Instructions/Exercises/03-document-intelligence.md
@@ -1,7 +1,13 @@
 ---
 lab:
-    title: 'Extract data with Azure Document Intelligence'
-    description: 'Use prebuilt and custom Document Intelligence models to extract structured data from documents.'
+  title: Extract data with Azure Document Intelligence
+  description: Use prebuilt and custom Document Intelligence models to extract structured data from documents.
+  duration: 45 minutes
+  level: 300
+  islab: true
+  primarytopics:
+    - Azure
+    - Azure Document Intelligence
 ---
 
 # Extract data with Azure Document Intelligence

--- a/Instructions/Exercises/04-knowledge-mining.md
+++ b/Instructions/Exercises/04-knowledge-mining.md
@@ -1,7 +1,12 @@
 ---
 lab:
-    title: 'Create a knowledge mining solution'
-    description: 'Use Azure AI Search to extract key information from documents and make it easier to search and analyze.'
+  title: Create a knowledge mining solution
+  description: Use Azure AI Search to extract key information from documents and make it easier to search and analyze.
+  duration: 40 minutes
+  level: 200
+  islab: true
+  primarytopics:
+    - Azure
 ---
 
 # Create a knowledge mining solution

--- a/Instructions/Exercises/05-rag-pipeline.md
+++ b/Instructions/Exercises/05-rag-pipeline.md
@@ -1,7 +1,13 @@
 ---
 lab:
-    title: 'Build an automated RAG ingestion pipeline with Content Understanding'
-    description: 'Use Azure Content Understanding, Azure AI Search, and Azure OpenAI to build a continuous multimodal RAG ingestion pipeline.'
+  title: Build an automated RAG ingestion pipeline with Content Understanding
+  description: Use Azure Content Understanding, Azure AI Search, and Azure OpenAI to build a continuous multimodal RAG ingestion pipeline.
+  duration: 45 minutes
+  level: 300
+  islab: true
+  primarytopics:
+    - Azure
+    - Azure Content Understanding
 ---
 
 # Build an automated RAG ingestion pipeline with Content Understanding

--- a/Instructions/Labs/01-content-understanding.md
+++ b/Instructions/Labs/01-content-understanding.md
@@ -1,7 +1,12 @@
 ---
 lab:
-    title: 'Extract information from multimodal content'
-    description: 'Use Azure AI Content Understanding to extract insights from documents, images, audio recordings, and videos.'
+  title: Extract information from multimodal content
+  description: Use Azure AI Content Understanding to extract insights from documents, images, audio recordings, and videos.
+  duration: 40 minutes
+  level: 100
+  islab: true
+  primarytopics:
+    - Azure
 ---
 
 # Extract information from multimodal content

--- a/Instructions/Labs/02-content-understanding-api.md
+++ b/Instructions/Labs/02-content-understanding-api.md
@@ -1,7 +1,12 @@
 ---
 lab:
-    title: 'Develop a Content Understanding client application'
-    description: 'Use Azure AI Content Understanding REST API to develop a client app for an analyzer.'
+  title: Develop a Content Understanding client application
+  description: Use Azure AI Content Understanding REST API to develop a client app for an analyzer.
+  duration: 30 minutes
+  level: 200
+  islab: true
+  primarytopics:
+    - Azure
 ---
 
 # Develop a Content Understanding client application

--- a/Instructions/Labs/03-prebuilt-doc-intelligence-model.md
+++ b/Instructions/Labs/03-prebuilt-doc-intelligence-model.md
@@ -1,7 +1,12 @@
 ---
 lab:
-    title: 'Analyze forms with prebuilt Azure AI Document Intelligence models'
-    description: 'Use prebuilt Azure AI Document Intelligence models to process text fields from documents.'
+  title: Analyze forms with prebuilt Azure AI Document Intelligence models
+  description: Use prebuilt Azure AI Document Intelligence models to process text fields from documents.
+  duration: 30 minutes
+  level: 200
+  islab: true
+  primarytopics:
+    - Azure
 ---
 
 # Analyze forms with prebuilt Azure AI Document Intelligence models

--- a/Instructions/Labs/04-custom-doc-intelligence-model.md
+++ b/Instructions/Labs/04-custom-doc-intelligence-model.md
@@ -1,7 +1,12 @@
 ---
 lab:
-    title: 'Analyze forms with custom Azure AI Document Intelligence models'
-    description: 'Create a custom Document Intelligence model to extract specific data from documents.'
+  title: Analyze forms with custom Azure AI Document Intelligence models
+  description: Create a custom Document Intelligence model to extract specific data from documents.
+  duration: 30 minutes
+  level: 300
+  islab: true
+  primarytopics:
+    - Azure
 ---
 
 # Analyze forms with custom Azure AI Document Intelligence models

--- a/Instructions/Labs/05-knowledge-mining.md
+++ b/Instructions/Labs/05-knowledge-mining.md
@@ -1,7 +1,12 @@
 ---
 lab:
-    title: 'Create a knowledge mining solution'
-    description: 'Use Azure AI Search to extract key information from documents and make it easier to search and analyze.'
+  title: Create a knowledge mining solution
+  description: Use Azure AI Search to extract key information from documents and make it easier to search and analyze.
+  duration: 40 minutes
+  level: 400
+  islab: true
+  primarytopics:
+    - Azure
 ---
 
 # Create a knowledge mining solution


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 10

- `Instructions/Exercises/01-content-understanding.md` (duration,level,islab,primarytopics)
- `Instructions/Exercises/02-content-understanding-api.md` (duration,level,islab,primarytopics)
- `Instructions/Exercises/03-document-intelligence.md` (duration,level,islab,primarytopics)
- `Instructions/Exercises/04-knowledge-mining.md` (duration,level,islab,primarytopics)
- `Instructions/Exercises/05-rag-pipeline.md` (duration,level,islab,primarytopics)
- `Instructions/Labs/01-content-understanding.md` (duration,level,islab,primarytopics)
- `Instructions/Labs/02-content-understanding-api.md` (duration,level,islab,primarytopics)
- `Instructions/Labs/03-prebuilt-doc-intelligence-model.md` (duration,level,islab,primarytopics)
- `Instructions/Labs/04-custom-doc-intelligence-model.md` (duration,level,islab,primarytopics)
- `Instructions/Labs/05-knowledge-mining.md` (duration,level,islab,primarytopics)
