### PR TITLE
tweak(lab-02): Add contentunderstanding to requirements.txt

### DIFF
--- a/Instructions/Exercises/02-content-understanding-api.md
+++ b/Instructions/Exercises/02-content-understanding-api.md
@@ -84,7 +84,7 @@ You'll use Visual Studio Code as your development environment.
     ```
    python -m venv labenv
    labenv\Scripts\activate
-   pip install -r requirements.txt azure-ai-contentunderstanding
+   pip install -r requirements.txt
     ```
 
 1. In the VS Code Explorer pane, open the **.env** file in the **Labfiles/02-content-understanding-api** folder.

--- a/Labfiles/02-content-understanding-api/requirements.txt
+++ b/Labfiles/02-content-understanding-api/requirements.txt
@@ -1,2 +1,2 @@
 python-dotenv
-
+azure-ai-contentunderstanding


### PR DESCRIPTION
# Module: 02
## Lab/Demo: 02

Changes proposed in this pull request:

- Add the azure-ai-contentunderstanding module to the Python requirements because students may overlook the instructions to install this module in addition to the requirements if they are used to the normal lab's Python project flow.