### PR TITLE
Fix custom model test image URL in test-model.py

### DIFF
--- a/Labfiles/03-document-intelligence/custom/Python/test-model.py
+++ b/Labfiles/03-document-intelligence/custom/Python/test-model.py
@@ -17,7 +17,7 @@ def main():
         key = os.getenv("DOC_INTELLIGENCE_KEY")
         model_id = os.getenv("MODEL_ID")
 
-        formUrl = "https://github.com/MicrosoftLearning/mslearn-ai-information-extraction/blob/main/Labfiles/custom-doc-intelligence/test1.jpg?raw=true"
+        formUrl = "https://raw.githubusercontent.com/MicrosoftLearning/mslearn-ai-information-extraction/main/Labfiles/03-document-intelligence/custom/test1.jpg"
 
         document_analysis_client = DocumentIntelligenceClient(
             endpoint=endpoint, credential=AzureKeyCredential(key)


### PR DESCRIPTION
The ormUrl in `Labfiles/03-document-intelligence/custom/Python/test-model.py` pointed to an outdated path (`Labfiles/custom-doc-intelligence/test1.jpg`) using the GitHub blob `?raw=true` URL, which no longer resolves.

This updates it to the correct raw.githubusercontent.com URL with the current repo path:
`https://raw.githubusercontent.com/MicrosoftLearning/mslearn-ai-information-extraction/main/Labfiles/03-document-intelligence/custom/test1.jpg`

Verified the new URL returns HTTP 200 and the script runs successfully.