### PR TITLE
Consolidate 5 labs into 2 modular labs (Fabrikam Logistics scenario)

### DIFF
--- a/Instructions/Exercises/Consolidated/A-extract-information-from-business-content.md
+++ b/Instructions/Exercises/Consolidated/A-extract-information-from-business-content.md
@@ -1,0 +1,162 @@
+---
+lab:
+    title: 'Extract information from business content'
+    description: 'Extract structured information from the documents, images, audio, and video that flow through Fabrikam Logistics. Start in the Content Understanding portal, then go deeper with the Content Understanding SDK and with prebuilt and custom Document Intelligence models. A modular lab you can complete end to end or one task at a time.'
+    level: 300
+    concepts: 'Content Understanding, custom analyzers, Document Intelligence, prebuilt models, custom extraction models'
+    duration: 40
+    islab: true
+    status: 'draft'
+---
+
+# Extract information from business content
+
+**Difficulty** ▰▰▰▱▱ **L300**  (filled bars out of 5; **L100** beginner → **L500** expert)
+
+Most of what a business knows is locked inside unstructured content: a PDF invoice, a photo of
+a contact card, a slide deck, a voicemail, a recorded call. People can read all of it. Software
+can't — until you extract it into fields. In this lab you'll build the extraction layer for
+**Fabrikam Logistics**, using the two Azure services designed for exactly this job.
+
+<style>
+/* "Ask Rani" just-in-time concept blocks */
+details.concept { margin:.6rem 0 1rem; }
+details.concept > summary { display:inline-block; cursor:pointer; list-style:none;
+  font-size:.85em; font-weight:600; color:#0b6a8f; background:#0b6a8f12;
+  border:1px solid #0b6a8f33; border-radius:999px; padding:.2em .7em; }
+details.concept > summary::-webkit-details-marker { display:none; }
+details.concept > summary::before { content:"Ask Rani: "; font-weight:700; }
+details.concept > summary:hover { background:#0b6a8f; color:#fff; border-color:#0b6a8f; }
+details.concept[open] > summary { border-bottom-left-radius:0; border-bottom-right-radius:0; }
+details.concept .concept-body { border:1px solid #0b6a8f33; border-top:none;
+  border-radius:0 8px 8px 8px; padding:.6rem .9rem; background:#0b6a8f08; font-size:.95em; }
+</style>
+
+<details markdown="1" class="concept">
+<summary>Content Understanding or Document Intelligence?</summary>
+<div class="concept-body" markdown="1">
+
+Both are part of **Foundry Tools**, and they solve different halves of the problem.
+
+**Azure Content Understanding** is LLM-powered. You describe the fields you want in plain
+language and it works across *any* modality — documents, images, audio, and video. Use it when
+the content is varied or unstructured, or when you want a generated summary rather than a
+literal value off the page.
+
+**Azure Document Intelligence** is deterministic OCR-based extraction, tuned for documents. It
+ships prebuilt models for common types (invoices, receipts, IDs), and you can train a **custom**
+model on your own form layout. Use it when you need high-accuracy, repeatable, position-aware
+extraction from documents that look the same every time.
+
+Real solutions use both. This lab does too.
+
+[Learn more →](https://learn.microsoft.com/azure/ai-services/content-understanding/overview)
+
+</div>
+</details>
+
+**Your scenario:** you work at **Fabrikam Logistics**, a freight-forwarding company. Every day
+the company receives supplier invoices in a dozen different layouts, contact cards collected by
+reps at trade shows, quarterly review slides, voicemails from customers, and recordings of
+operations calls. Nobody can keep up. Your job is to turn that flood of content into structured
+fields that the rest of the business can actually use.
+
+You'll start with the **Core** task, which gets you extracting from all four modalities as
+quickly as possible. From there, a set of **Optional** tasks takes you from clicking in a portal
+to writing the code, and from generative extraction to trained, deterministic models.
+
+> **Note**: Some of the technologies used in this exercise are in preview or in active
+> development. You may experience some unexpected behavior, warnings, or errors.
+
+## What you'll learn
+
+By completing the **Core** task of this exercise, you'll be able to:
+
+- **Define a custom schema and build an analyzer** in Content Understanding that extracts named
+  fields from documents, images, audio, and video — then test it against content it hasn't seen.
+
+The **Optional** tasks let you additionally:
+
+- **Create and call analyzers in code** with the Content Understanding Python SDK, so extraction
+  runs inside your application instead of a portal.
+- **Extract invoice data with a prebuilt model** using Azure Document Intelligence, with no
+  schema and no training at all.
+- **Train a custom extraction model** on your own form layout, and call it from Python when the
+  prebuilt models don't fit your documents.
+
+## How this lab is organized
+
+This lab is **modular**. Each task is written to be completed **on its own, starting fresh** —
+so you can pick a single task and do just that one. Every code task also shares one starter
+folder, one virtual environment, and one `.env`, so if you'd rather work straight through, you
+can.
+
+1. **Start with [Getting started](A0-getting-started.md)** — create your Microsoft Foundry
+   resource and project, connect Content Understanding, get the sample content and the starter
+   code, and set up your `.env`. Every task begins here; if you're doing the whole lab in one
+   sitting, you only need to do this once.
+2. **Do any task.** Each task lists the setup it needs so you can start it independently. If
+   you're moving straight from the previous task, a short *"Continuing from a previous task?"*
+   note at the top lets you skip the repeated setup and keep going.
+
+## Lab at a glance
+
+Complete the **Core** task first (about **40 minutes**) — it ends with four working analyzers
+covering documents, images, audio, and video. Then expand any **Optional** tasks that interest
+you. The full lab, including all optional tasks, takes about **2 hours 15 minutes**.
+
+| Section | Task | Difficulty | Time |
+| --- | --- | --- | --- |
+| **Core** | [Task 1 – Extract fields from multimodal content](A1-extract-fields-from-multimodal-content.md) | ▰▰▱▱▱ L200 | ~40 min |
+| *Optional* | [Task 2 – Build an analyzer with the Python SDK](A2-build-an-analyzer-with-the-python-sdk.md) | ▰▰▰▱▱ L300 | ~30 min |
+| *Optional* | [Task 3 – Extract invoice data with a prebuilt model](A3-extract-invoice-data-with-a-prebuilt-model.md) | ▰▰▰▱▱ L300 | ~25 min |
+| *Optional* | [Task 4 – Train a custom extraction model](A4-train-a-custom-extraction-model.md) | ▰▰▰▱▱ L300 | ~40 min |
+
+**Choosing your path** — pick the tasks that fit the time you have:
+
+- **Core only (~40 min):** do Task 1 and stop. You'll have used Content Understanding across
+  every modality.
+- **Core + code (~1h 10m):** add **Task 2** to do the same thing from Python.
+- **Documents in depth (~1h 45m):** do Task 1, then **Task 3** and **Task 4** to compare
+  Content Understanding against Document Intelligence on the same kind of document.
+- **Everything (~2h 15m):** all four tasks.
+
+## Two services, one extraction layer
+
+The tasks are ordered so each one changes exactly one thing:
+
+- In **Task 1**, you use **Content Understanding** through the portal. You define what you want
+  in a schema and the service figures out how to get it — across documents, images, audio, and
+  video.
+- In **Task 2**, you do the *same* Content Understanding work from **Python**. Same schema, same
+  analyzer, now callable from an application.
+- In **Task 3**, you switch to **Document Intelligence** and a **prebuilt** model. No schema at
+  all: the model already knows what an invoice is.
+- In **Task 4**, you stay in Document Intelligence but **train your own model** on labeled
+  Fabrikam Logistics forms — the answer for documents no prebuilt model covers.
+
+Seeing the generative approach first is what makes the deterministic, trained approach in
+Tasks 3 and 4 meaningful.
+
+## Summary
+
+Across this lab you:
+
+- Built **custom Content Understanding analyzers** for documents, images, audio, and video, and
+  tested them on unseen content.
+- (Optionally) created and called an analyzer with the **Content Understanding Python SDK**.
+- (Optionally) extracted invoice fields with a **prebuilt Document Intelligence model**.
+- (Optionally) **trained and tested a custom extraction model** on your own form layout.
+
+Together these cover the full range of extraction: generative for anything, prebuilt for common
+document types, and trained for documents that are uniquely yours.
+
+Once your content is extracted, the natural next step is making it findable and answerable — see
+[Make extracted information searchable](B-make-extracted-information-searchable.md).
+
+## Clean up
+
+If you're finished, delete the resources you created to avoid unnecessary Azure costs.
+
+1. In the [Azure portal](https://portal.azure.com), navigate to the resource group that contains your Foundry and Document Intelligence resources.
+1. On the toolbar, select **Delete resource group**, enter the resource group name, and confirm.

--- a/Instructions/Exercises/Consolidated/A0-getting-started.md
+++ b/Instructions/Exercises/Consolidated/A0-getting-started.md
@@ -1,0 +1,166 @@
+---
+lab:
+    title: 'Getting started: set up your environment'
+    description: 'Shared setup for the Extract information from business content lab: create a Microsoft Foundry resource and project, connect Content Understanding, get the sample content and starter code, and configure your environment. Complete this once before any task.'
+    level: 300
+    concepts: 'environment setup, Microsoft Foundry resource, Content Understanding'
+    status: 'draft'
+---
+
+# Getting started
+
+This page sets up everything the **Extract information from business content** lab needs.
+**Every task begins here** — complete this page first. Each task is written so you can then do
+it on its own; if you're working through the whole lab in one sitting, you only need to do this
+setup once.
+
+**Your scenario:** you work at **Fabrikam Logistics**, a freight-forwarding company. Across the
+lab you'll build the extraction layer that turns the company's incoming documents, images,
+audio, and video into structured fields.
+
+> **Note**: Some of the technologies used in this lab are in preview or in active development.
+> You may experience some unexpected behavior, warnings, or errors.
+
+## Prerequisites
+
+Before starting, ensure you have:
+
+- An [Azure subscription](https://azure.microsoft.com/free/) with sufficient permissions and quota to provision Azure AI resources
+- [Visual Studio Code](https://code.visualstudio.com/) installed on your local machine
+- [Python 3.11](https://www.python.org/downloads/) or later installed\*
+- [Git](https://git-scm.com/downloads) installed on your local machine
+- Basic familiarity with Python (needed for Tasks 2, 3, and 4 only)
+
+> \* The Azure SDK for Python supports Python 3.9 or later. This lab was tested with Python 3.13.
+
+## Create a Microsoft Foundry resource and project
+
+Tasks 1 and 2 use **Azure Content Understanding**, which runs on a Microsoft Foundry resource.
+
+1. In a web browser, open the [Microsoft Foundry portal](https://ai.azure.com) at `https://ai.azure.com` and sign in using your Azure credentials. Close any tips or quick start panes that are opened the first time you sign in.
+
+    > **Important**: For this lab, you're using the **New** Foundry experience. Make sure the **New Foundry** toggle is on.
+
+1. If you aren't prompted to create a project automatically, select the project name in the upper-left corner, and then select **Create new project**.
+
+1. Give your project a name (for example, `fabrikam-extraction`) and expand **Advanced options** to specify the following settings:
+    - **Foundry resource**: *A valid name for your Foundry resource*
+    - **Region**: Choose one of the following supported regions:\*
+        - Australia East
+        - East US
+        - East US 2
+        - Japan East
+        - North Europe
+        - South Central US
+        - Southeast Asia
+        - Sweden Central
+        - UK South
+        - West Europe
+        - West US
+        - West US 3
+    - **Subscription**: *Your Azure subscription*
+    - **Resource group**: *Create or select a resource group*
+
+    > \*Azure Content Understanding is available in selected regions. See the [region support documentation](https://learn.microsoft.com/azure/ai-services/content-understanding/language-region-support) for the latest availability.
+
+1. Select **Create** and wait for your project to be created. This creates a project and its parent Foundry resource.
+
+1. Once created, select the project name at the top of the page, and select **Project details**. On that page, follow the link to the parent resource. **Leave this browser tab open** — you'll copy the endpoint and key from it for Task 2.
+
+## Connect Content Understanding to your Foundry resource
+
+Content Understanding analyzers use models that are deployed in your Foundry resource. Connecting
+the resource in Content Understanding Studio deploys them for you.
+
+1. In a new tab, navigate to [Content Understanding Studio](https://contentunderstanding.ai.azure.com/home) at `https://contentunderstanding.ai.azure.com/home` and sign in with your credentials.
+1. Select the settings gear icon on the top navigation bar, and select **+ Add resource**.
+1. Select your subscription and the resource group where you created your Foundry resource, then select your Foundry resource name from the dropdown. This is the parent resource of the project you created above.
+1. Make sure the **Enable auto-deployment** box is checked, then select **Next** and **Save**.
+
+    > **Tip**: Auto-deployment deploys the chat and embedding models that custom analyzers need — currently a `gpt-5.2`-family completion model and `text-embedding-3-large`. Without it, building an analyzer fails with a missing-model error.
+
+1. Wait while the required models deploy.
+
+> **Note**: Content Understanding has two authoring experiences. The **Foundry portal**
+> (`https://ai.azure.com`) is the primary one for agentic workflows. **Content Understanding
+> Studio** (`https://contentunderstanding.ai.azure.com`) is the complementary experience
+> optimized for building and labeling custom analyzers — that's what this lab uses.
+
+## Create a Document Intelligence resource (Tasks 3 and 4 only)
+
+Skip this section if you're only doing Tasks 1 and 2.
+
+1. In a web browser, navigate to **Document Intelligence Studio** at `https://documentintelligence.ai.azure.com/studio` and sign in with your Azure credentials.
+1. In the Studio, select the **Settings** icon (⚙) in the upper-right corner, and then select the **Resource** tab.
+1. Select **Create a new resource** and configure it with the following settings:
+    - **Subscription**: *Your Azure subscription*
+    - **Resource group**: *The same resource group you used above*
+    - **Name**: *A valid name for your Document Intelligence resource*
+    - **Region**: *Any available region*
+    - **Pricing tier**: Free F0 (*if you don't have a Free tier available, select Standard S0*)
+1. Select **Create** and wait for the resource to be deployed. The Studio connects to the new resource automatically.
+
+## Download the sample content
+
+Task 1 analyzes a set of Fabrikam Logistics sample files: an invoice, a slide image, a voicemail
+recording, and a recorded operations call.
+
+1. In a new browser tab, download [content.zip](https://github.com/microsoftlearning/mslearn-ai-information-extraction/raw/main/Labfiles/content/content.zip) from `https://github.com/microsoftlearning/mslearn-ai-information-extraction/raw/main/Labfiles/content/content.zip` and save it in a local folder.
+1. Extract the downloaded *content.zip* file and view the files it contains. You'll upload these into Content Understanding in Task 1.
+
+## Get the starter code
+
+Tasks 2, 3, and 4 write and run Python. Task 1 doesn't need any of this, so you can skip ahead
+if you're only doing the Core task.
+
+1. In VS Code, open the Command Palette (**Ctrl+Shift+P**), run **Git: Clone**, and enter:
+
+    ```
+    https://github.com/microsoftlearning/mslearn-ai-information-extraction
+    ```
+
+1. Open the cloned repo, then **File > Open Folder** and select `mslearn-ai-information-extraction/Labfiles/A-extract-information-from-business-content/Python`. This single folder holds the starter code for **every** code task in this lab — you use one virtual environment and one `.env` throughout.
+
+1. Right-click **requirements.txt** and choose **Open in Integrated Terminal**. Then create a virtual environment and install packages:
+
+    ```
+    python -m venv labenv
+    .\labenv\Scripts\Activate.ps1
+    pip install -r requirements.txt
+    ```
+
+    > **Note**: This installs the [azure-ai-contentunderstanding](https://pypi.org/project/azure-ai-contentunderstanding/) and [azure-ai-documentintelligence](https://learn.microsoft.com/python/api/overview/azure/ai-documentintelligence-readme) Python SDK packages and their dependencies.
+
+1. Copy **.env.example** to a new file named **.env** in the same folder, then fill in the values for the tasks you plan to do:
+
+    | Key | Where to get it | Needed by |
+    | --- | --- | --- |
+    | `FOUNDRY_ENDPOINT` | Foundry resource > **Overview**, or **Resource Management > Keys and Endpoint** | Task 2 |
+    | `FOUNDRY_KEY` | Foundry resource > **Resource Management > Keys and Endpoint** | Task 2 |
+    | `ANALYZER_NAME` | Already filled in as `fabrikam-contact-analyzer` | Task 2 |
+    | `DOC_INTELLIGENCE_ENDPOINT` | Document Intelligence resource > **Keys and Endpoint** | Tasks 3, 4 |
+    | `DOC_INTELLIGENCE_KEY` | Document Intelligence resource > **Keys and Endpoint** | Tasks 3, 4 |
+    | `CUSTOM_MODEL_ID` | The Model ID you choose when you train in Task 4 | Task 4 |
+
+1. Save the file (**Ctrl+S**).
+
+    > **Note**: These tasks authenticate with resource keys because that's the quickest path in a lab. For production, Microsoft recommends [Microsoft Entra ID authentication](https://learn.microsoft.com/azure/ai-services/authentication) with `DefaultAzureCredential` instead of keys.
+
+## Check you're ready for a task
+
+Each task needs specific values in your `.env`. Before starting a task, run the preflight check
+from the `Python` folder you opened above — it reads your `.env` and tells you what (if anything)
+is missing:
+
+```
+python ../setup/check_env.py --task 2
+```
+
+Swap `2` for the task number you're about to start. That's it — head to any task:
+
+| Task | Page |
+| --- | --- |
+| Task 1 – Extract fields from multimodal content | [A1](A1-extract-fields-from-multimodal-content.md) |
+| Task 2 – Build an analyzer with the Python SDK | [A2](A2-build-an-analyzer-with-the-python-sdk.md) |
+| Task 3 – Extract invoice data with a prebuilt model | [A3](A3-extract-invoice-data-with-a-prebuilt-model.md) |
+| Task 4 – Train a custom extraction model | [A4](A4-train-a-custom-extraction-model.md) |

--- a/Instructions/Exercises/Consolidated/A1-extract-fields-from-multimodal-content.md
+++ b/Instructions/Exercises/Consolidated/A1-extract-fields-from-multimodal-content.md
@@ -1,0 +1,402 @@
+---
+lab:
+    title: 'Task 1 – Extract fields from multimodal content'
+    description: 'Use Azure Content Understanding to define custom schemas and build analyzers that extract named fields from an invoice, a slide image, a voicemail recording, and a recorded call.'
+    level: 200
+    concepts: 'Content Understanding, prebuilt analyzers, custom schemas, multimodal extraction'
+    islab: true
+    status: 'draft'
+---
+
+# Task 1 — Extract fields from multimodal content
+
+*Part of the **Extract information from business content** lab. New here? Start with [Getting started](A0-getting-started.md).*
+
+> **Set up (start here):** This task needs a Microsoft Foundry resource with Content Understanding
+> connected, plus the sample content files. If you haven't already, complete
+> [Getting started](A0-getting-started.md) to create your Foundry project, connect Content
+> Understanding Studio with auto-deployment enabled, and download and extract **content.zip**.
+> This task is done entirely in the browser — no code, no `.env`. If you want to confirm that,
+> run the following from the `Python` folder:
+
+```
+python ../setup/check_env.py --task 1
+```
+
+---
+
+Fabrikam Logistics receives four very different kinds of content, and all four hide information
+somebody currently retypes by hand. In this task you'll build a Content Understanding analyzer
+for each one: a **supplier invoice** (document), a **quarterly review slide** (image), a
+**customer voicemail** (audio), and a **recorded operations call** (video).
+
+The pattern is identical every time, which is the point: **describe the fields you want, test,
+build an analyzer, then run it against content it has never seen.**
+
+<style>
+/* "Ask Rani" just-in-time concept blocks */
+details.concept { margin:.6rem 0 1rem; }
+details.concept > summary { display:inline-block; cursor:pointer; list-style:none;
+  font-size:.85em; font-weight:600; color:#0b6a8f; background:#0b6a8f12;
+  border:1px solid #0b6a8f33; border-radius:999px; padding:.2em .7em; }
+details.concept > summary::-webkit-details-marker { display:none; }
+details.concept > summary::before { content:"Ask Rani: "; font-weight:700; }
+details.concept > summary:hover { background:#0b6a8f; color:#fff; border-color:#0b6a8f; }
+details.concept[open] > summary { border-bottom-left-radius:0; border-bottom-right-radius:0; }
+details.concept .concept-body { border:1px solid #0b6a8f33; border-top:none;
+  border-radius:0 8px 8px 8px; padding:.6rem .9rem; background:#0b6a8f08; font-size:.95em; }
+</style>
+
+<details markdown="1" class="concept">
+<summary>What's the difference between a schema and an analyzer?</summary>
+<div class="concept-body" markdown="1">
+
+A **schema** is the list of fields you want, each with a name, a description, a value type, and a
+method. It's the *what*.
+
+An **analyzer** is a schema that's been built into a reusable, callable service asset. Once built,
+you can point it at new content — in the portal, or from code, as you'll do in Task 2 — and get
+those fields back. It's the *how you use it again*.
+
+The **method** on each field matters:
+
+- **Extract** pulls a value that's literally present in the content (an invoice total).
+- **Generate** produces a value the model infers from the content (a summary, a count of charts).
+
+</div>
+</details>
+
+> **Note**: If you're only interested in one modality, you can do just that section. Each of the
+> four sections below is self-contained. For the full picture, do all four.
+
+## Try prebuilt analyzers first
+
+Before building anything custom, see what you get for free. Content Understanding includes
+prebuilt **Read** and **Layout** analyzers that extract text and structure from documents with no
+configuration at all.
+
+1. In the [Microsoft Foundry portal](https://ai.azure.com), make sure the **New Foundry** toggle is on.
+1. Select **Build** in the upper-right menu, then select **Deployments** in the left pane.
+1. Select the **AI Services** tab to view the prebuilt models provided by Foundry Tools.
+1. Find and select **Azure Content Understanding - Layout**.
+
+    This opens the Layout analyzer playground, where you can test the layout model on sample data
+    or your own files.
+
+1. In the playground, use the option to upload your own data and upload the **invoice-1234.pdf** file from the folder where you extracted the content files. This is the supplier invoice:
+
+    ![Image of an invoice number 1234.](../media/invoice-1234.png)
+
+1. Run the analyzer and wait for analysis to complete.
+1. Review the results. You can view the extracted content either as formatted output or as raw JSON. Notice that Layout extracts text, tables, and structural elements such as paragraphs and sections.
+
+    > **Note**: The prebuilt **Read** and **Layout** analyzers extract content from documents without using a generative AI model. **Read** extracts text elements (words, paragraphs, formulas, and barcodes); **Layout** additionally extracts tables, figures, document structure, hyperlinks, and annotations. They're great for general-purpose extraction — but neither one gives you *specific* fields like an invoice total or a vendor name. That's what you'll build next.
+
+1. Optionally, go back to the **AI Services** tab and try **Azure Content Understanding - Read** with the same file to compare. Notice that Read extracts text without layout analysis.
+
+## Set up Content Understanding Studio for custom analyzers
+
+To extract specific fields, you build **custom analyzers** in Content Understanding Studio.
+
+1. In a new browser tab, open [Content Understanding Studio](https://contentunderstanding.ai.azure.com) at `https://contentunderstanding.ai.azure.com`.
+1. If prompted, sign in with the same Azure credentials you used for the Foundry portal.
+1. If you didn't already connect your resource in [Getting started](A0-getting-started.md), go to the **Settings** page, select **+ Add resource**, select your Foundry resource, and select **Next** > **Save**.
+
+    > **Tip**: Make sure the **Enable autodeployment for required models if no defaults are available** checkbox is selected, so your resource gets the models custom analyzers depend on.
+
+1. Once your resource is connected, select **Content Understanding** in the top navigation to go to the home page.
+
+### Create a storage account
+
+Content Understanding Studio stores the data you use to build custom analyzers in Azure Blob
+Storage. Create one in the same resource group as your Foundry resource.
+
+1. In a new browser tab, open the [Azure portal](https://portal.azure.com) at `https://portal.azure.com` and sign in with your Azure credentials.
+1. Select **+ Create a resource**, search for `Storage account`, and create a new **Storage account** resource with the following settings:
+    - **Subscription**: *Your Azure subscription*
+    - **Resource group**: *The same resource group as your Foundry resource*
+    - **Storage account name**: *Enter a globally unique name*
+    - **Region**: *The same region as your Foundry resource*
+    - **Preferred storage type**: Azure Blob Storage or Azure Data Lake Storage Gen 2
+    - **Performance**: Standard
+    - **Redundancy**: Locally-redundant storage (LRS)
+1. Select **Review + create**, and then **Create**. Wait for deployment to complete.
+
+## Extract fields from an invoice document
+
+Fabrikam Logistics receives supplier invoices constantly, in layouts that vary by supplier. Build
+an analyzer that pulls the same fields out of all of them.
+
+### Define a schema for invoice analysis
+
+1. In Content Understanding Studio, select the **Get started** button in the custom projects section, and select **Create**.
+1. Select **Extract content and fields with a custom schema**, then create a project with the following settings:
+    - **Project name**: `Invoice analysis`
+    - **Description**: `Extract data from a supplier invoice`
+    - **Advanced settings**
+        - **Connected resource**: *Confirm your Foundry resource is selected*
+        - **Connect storage account**: *Select the storage account you just created*
+        - **Blob container**: *Create a new container named* `content-understanding`
+1. Wait for the project to be created.
+
+    > **Tip**: If an error accessing storage occurs, wait a minute and try again. Permissions for a new resource can take a few minutes to propagate.
+
+1. Upload the **invoice-1234.pdf** file from the folder where you extracted the content files.
+
+    Content Understanding classifies your data and recommends analyzer templates based on the
+    uploaded content.
+
+1. In the **Choose a template** window, select the **Invoice** template and select **Save**.
+
+    The *Invoice* template includes common invoice fields. Use the schema editor to delete
+    suggested fields you don't need, and add custom fields you do.
+
+1. In the list of suggested fields, select **BillingAddress**. Fabrikam Logistics doesn't need it for this invoice format, so use the **Delete field** (**&#128465;**) icon at the end of the selected field row to delete it.
+1. In the top bar of the schema tab, select **Suggest**. This looks at the sample invoice and suggests which fields should be part of your schema. Expand the **Items** field to see the suggested subfields. Adding those fields replaces your existing schema, so be careful in your own projects if you've already edited one. Select **Save**.
+1. Use the **+ Add new field** button to add the following field, selecting **Save** (**&#10003;**) for it:
+
+    | Field name | Field description | Value type | Method |
+    |--|--|--|--|
+    | `TotalQuantity` | `Total number of items on the invoice` | String | Auto |
+
+1. Verify that your completed schema looks like this, and select **Save**.
+
+    ![Screenshot of the invoice analyzer schema in Content Understanding Studio showing fields such as VendorName, InvoiceDate, SubTotal, Items, and TotalQuantity.](../media/invoice-schema.png)
+
+1. Select the **Test** tab, then select **Run analysis** to test your schema. Wait for analysis to complete.
+
+1. Review the analysis results, which should look similar to this:
+
+    ![Screenshot of invoice analysis test results in Content Understanding Studio showing extracted field values from the sample invoice.](../media/invoice-analysis.png)
+
+1. View the details of the fields that were identified in the **Fields** pane.
+
+### Build and test an analyzer for invoices
+
+Now that the schema works, build it into a reusable analyzer.
+
+1. Select the **Build analyzer** button at the top, and build a new analyzer with the following properties (typed exactly as shown here):
+    - **Name**: `invoiceanalyzer`
+    - **Description**: `Invoice analyzer`
+1. When the analyzer has been built, select **Jump to analyzer list** to view all built analyzers, then select the **invoiceanalyzer** link. The fields defined in the analyzer's schema are displayed.
+1. On the **invoiceanalyzer** page, select the **Test** tab.
+1. Upload **invoice-1235.pdf** from the folder where you extracted the content files, and run the analysis.
+
+    This is a *different* invoice the analyzer has never seen:
+
+    ![Image of an invoice number 1235.](../media/invoice-1235.png)
+
+1. Review the **Fields** pane, and verify that the analyzer extracted the correct fields from the test invoice.
+1. Review the **Results** pane to see the JSON response that the analyzer would return to a client application.
+1. Close the **invoiceanalyzer** page to return to the analyzer list.
+
+## Extract information from a slide image
+
+Fabrikam Logistics' quarterly review decks contain charts that nobody has time to transcribe.
+
+### Define a schema for image analysis
+
+1. On the **Project list** tab, select **Create**, select **Extract content and fields with a custom schema**, then create a project with the following settings:
+    - **Project name**: `Slide analysis`
+    - **Description**: `Extract data from an image of a slide`
+    - **Advanced settings**: *Verify the settings are the same as the last project*
+1. Wait for the project to be created.
+
+1. Upload the **slide-1.jpg** file from the folder where you extracted the content files. Then select the **Image analysis** template and select **Save**.
+
+    The *Image analysis* template doesn't include any predefined fields — you define everything
+    you want to extract.
+
+1. Use the **+ Add new field** button to add the following fields, selecting **Save changes** (**&#10003;**) for each new field:
+
+    | Field name | Field description | Value type | Method |
+    |--|--|--|--|
+    | `Title` | `Slide title` | String | Generate |
+    | `Summary` | `Summary of the slide` | String | Generate |
+    | `Charts` | `Number of charts on the slide` | Integer | Generate |
+
+1. Use the **+ Add new field** button to add a new field named `QuarterlyRevenue` with the description `Revenue per quarter` and the value type **List of objects**. Then select the table icon next to the value type dropdown. On the page for the table subfields that opens, add the following subfields:
+
+    | Field name | Field description | Value type | Method |
+    |--|--|--|--|
+    | `Quarter` | `Which quarter?` | String | Generate |
+    | `Revenue` | `Revenue for the quarter` | Number | Generate |
+
+1. Select **Back** to return to the top level of your schema, and use the **+ Add new field** button to add a new field named `ProductCategories` with the description `Product categories` and the value type **List of objects**. Select the table icon next to the value type to open the subfields page, and add the following subfields:
+
+    | Field name | Field description | Value type | Method |
+    |--|--|--|--|
+    | `ProductCategory` | `Product category name` | String | Generate |
+    | `RevenuePercentage` | `Percentage of revenue` | Number | Generate |
+
+1. Select **Back** to return to the top level of your schema, and verify that it looks like this. Then select **Save**.
+
+    ![Screenshot of the image analyzer schema in Content Understanding Studio showing fields for Title, Summary, Charts, QuarterlyRevenue, and ProductCategories.](../media/slide-schema.png)
+
+1. Select the **Test** tab, then **Run analysis** and wait for analysis to complete.
+1. Review the analysis results, which should look similar to this:
+
+    ![Screenshot of image analysis test results in Content Understanding Studio showing extracted fields from the slide including revenue data and product categories.](../media/slide-analysis.png)
+
+1. View the details of the fields that were identified in the **Fields** pane, expanding the **QuarterlyRevenue** and **ProductCategories** fields to see the subfield values.
+
+### Build and test a slide analyzer
+
+1. Select the **Build analyzer** button at the top, and build a new analyzer with the following properties (typed exactly as shown here):
+    - **Name**: `slideanalyzer`
+    - **Description**: `Slide image analyzer`
+1. When the analyzer has been built, select **Jump to analyzer list**, then select the **slideanalyzer** link. The fields defined in the analyzer's schema are displayed.
+1. On the **slideanalyzer** page, select the **Test** tab.
+1. Use the **+ Upload test files** button to upload **slide-2.jpg** from the folder where you extracted the content files, and run the analysis.
+
+1. Review the **Fields** pane, and verify that the analyzer extracted the correct fields from the slide image.
+
+    > **Note**: Slide 2 doesn't include a breakdown by product category, so the product category revenue data isn't found. An analyzer returning nothing for a field that genuinely isn't there is correct behavior — worth remembering when you consume these results in code.
+
+1. Review the **Results** pane to see the JSON response that the analyzer would return to a client application.
+1. Close the **slideanalyzer** page.
+
+## Extract information from a voicemail recording
+
+Customers leave voicemails for the Fabrikam Logistics service desk. Each one contains a callback
+number and a request that somebody has to action.
+
+### Define a schema for audio analysis
+
+1. On the **Project list** tab, select **Create**, select **Extract content and fields with a custom schema**, then create a project with the following settings:
+    - **Project name**: `Voicemail analysis`
+    - **Description**: `Extract data from a voicemail recording`
+    - **Advanced settings**: *Verify the settings are the same as the last project*
+1. Wait for the project to be created.
+
+1. Upload the **call-1.mp3** file from the folder where you extracted the content files. Then select the **Audio analysis** template and select **Save**.
+1. In the **Content** pane on the right, select **Get transcription preview** to see a transcription of the recorded message.
+
+    The *Audio analysis* template doesn't include any predefined fields — you define what you want
+    to extract.
+
+1. Use the **+ Add new field** button to add the following fields, selecting **Save** (**&#10003;**) for each new field:
+
+    | Field name | Field description | Value type | Method |
+    |--|--|--|--|
+    | `Caller` | `Person who left the message` | String | Generate |
+    | `Summary` | `Summary of the message` | String | Generate |
+    | `Actions` | `Requested actions` | String | Generate |
+    | `CallbackNumber` | `Telephone number to return the call` | String | Generate |
+    | `AlternativeContacts` | `Alternative contact details` | List of Strings | Generate |
+
+1. Select **Run analysis** and wait for analysis to complete.
+
+    Audio analysis can take some time. While you're waiting, you can play the audio file below:
+
+    <video controls src="../media/call-1.mp4" title="Call 1" width="300">
+        <track src="../media/call-1.vtt" kind="captions" srclang="en" label="English">
+    </video>
+
+    **Note**: This audio was generated using AI.
+
+1. Review the analysis results and view the details of the fields that were identified in the **Fields** pane, expanding the **AlternativeContacts** field to see the listed values.
+
+### Build and test a voicemail analyzer
+
+1. Select the **Build analyzer** button at the top, and build a new analyzer with the following properties (typed exactly as shown here):
+    - **Name**: `voicemailanalyzer`
+    - **Description**: `Voicemail audio analyzer`
+1. When the analyzer has been built, select **Jump to analyzer list**, then select the **voicemailanalyzer** link. The fields defined in the analyzer's schema are displayed.
+1. On the **voicemailanalyzer** page, select the **Test** tab.
+1. Use the **+ Upload test files** button to upload **call-2.mp3** from the folder where you extracted the content files, and run the analysis.
+
+    Audio analysis can take some time. While you're waiting, you can play the audio file below:
+
+    <video controls src="../media/call-2.mp4" title="Call 2" width="300">
+        <track src="../media/call-2.vtt" kind="captions" srclang="en" label="English">
+    </video>
+
+    **Note**: This audio was generated using AI.
+
+1. Review the **Fields** pane, and verify that the analyzer extracted the correct fields from the voice message.
+1. Review the **Results** pane to see the JSON response that the analyzer would return to a client application.
+1. Close the **voicemailanalyzer** page.
+
+## Extract information from a recorded call
+
+Finally, the hardest modality: a recorded operations call, where the useful information is spread
+across what people said *and* what they showed on screen.
+
+### Define a schema for video analysis
+
+1. In Content Understanding Studio, select **Create project** on the home page (or use the navigation to return to the home page first).
+1. Select **Extract content and fields with a custom schema**, then create a project with the following settings:
+    - **Project name**: `Operations call analysis`
+    - **Description**: `Extract data from a recorded operations call`
+1. Wait for the project to be created.
+
+1. Upload the **meeting-1.mp4** file from the folder where you extracted the content files. Then select the **Video analysis** template and select **Create**.
+1. In the **Content** pane on the right, select **Get transcription preview** to see a transcription of the recorded call.
+
+    The *Video analysis* template extracts data for each segment. It doesn't include any
+    predefined fields — you define what you want to extract.
+
+1. Use the **+ Add new field** button to add the following fields, selecting **Save** (**&#10003;**) for each new field:
+
+    | Field name | Field description | Value type | Method |
+    |--|--|--|--|
+    | `Summary` | `Summary of the discussion` | String | Generate |
+    | `Participants` | `Count of call participants` | Integer | Generate |
+    | `ParticipantNames` | `Names of call participants` | List of Strings | Generate |
+    | `SharedSlides` | `Descriptions of any slides presented` | List of Strings | Generate |
+    | `AssignedActions` | `Tasks assigned to participants` | List of Objects | Generate |
+
+1. When you enter the **AssignedActions** field, in the table of subfields, create the following subfields:
+
+    | Field name | Field description | Value type | Method |
+    |--|--|--|--|
+    | `Task` | `Description of the task` | String | Generate |
+    | `AssignedTo` | `Who the task is assigned to` | String | Generate |
+
+1. Select **Back** to return to the top level of your schema, verify that it looks correct, and select **Save**.
+
+1. Select **Run analysis** and wait for analysis to complete.
+
+    Video analysis can take some time. While you're waiting, you can view the video below:
+
+    <video controls src="../media/meeting-1.mp4" title="Meeting 1" width="480">
+        <track src="../media/meeting-1.vtt" kind="captions" srclang="en" label="English">
+    </video>
+
+    **Note**: This video was generated using AI.
+
+1. When analysis is complete, review the results.
+1. In the **Fields** pane, view the extracted data.
+
+### Build and test a call analyzer
+
+1. Select the **Build analyzer** button at the top, and build a new analyzer with the following properties (typed exactly as shown here):
+    - **Name**: `meetinganalyzer`
+    - **Description**: `Operations call video analyzer`
+1. Wait for the new analyzer to be ready (use the **Refresh** button to check).
+1. When the analyzer has been built, select **Jump to analyzer list**, then select the **meetinganalyzer** link. The fields defined in the analyzer's schema are displayed.
+1. On the **meetinganalyzer** page, select the **Test** tab.
+1. Use the **+ Upload test files** button to upload **meeting-2.mp4** from the folder where you extracted the content files, and run the analysis.
+
+    Video analysis can take some time. While you're waiting, you can view the video below:
+
+    <video controls src="../media/meeting-2.mp4" title="Meeting 2" width="480">
+        <track src="../media/meeting-2.vtt" kind="captions" srclang="en" label="English">
+    </video>
+
+    **Note**: This video was generated using AI.
+
+1. Review the **Fields** pane, and view the fields that the analyzer extracted for each shot in the recorded call.
+1. Review the **Results** pane to see the JSON response that the analyzer would return to a client application.
+1. Close the **meetinganalyzer** page.
+
+> ✅ **Checkpoint**: You've built four custom analyzers with Content Understanding — one each for
+> documents, images, audio, and video — and tested each against content it hadn't seen. The
+> workflow was identical every time: describe the fields, test, build, reuse. That's the Core of
+> this lab. The optional tasks below take the same idea into code, and then compare it against a
+> different service.
+
+---
+
+**Next (optional):** [Task 2 — Build an analyzer with the Python SDK](A2-build-an-analyzer-with-the-python-sdk.md) · [Task 3 — Extract invoice data with a prebuilt model](A3-extract-invoice-data-with-a-prebuilt-model.md)

--- a/Instructions/Exercises/Consolidated/A2-build-an-analyzer-with-the-python-sdk.md
+++ b/Instructions/Exercises/Consolidated/A2-build-an-analyzer-with-the-python-sdk.md
@@ -1,0 +1,242 @@
+---
+lab:
+    title: 'Task 2 – Build an analyzer with the Python SDK'
+    description: 'Use the Azure Content Understanding Python SDK to create an analyzer from a JSON schema and call it from a client application to extract contact details from scanned cards.'
+    level: 300
+    concepts: 'Content Understanding SDK, analyzer schemas, long-running operations'
+    islab: true
+    status: 'draft'
+---
+
+# Task 2 — Build an analyzer with the Python SDK
+
+*Part of the **Extract information from business content** lab. New here? Start with [Getting started](A0-getting-started.md).*
+
+> **Set up (start here):** This task needs a Microsoft Foundry resource with Content Understanding
+> connected, and the starter code. If you haven't already, complete
+> [Getting started](A0-getting-started.md) to create your project, connect Content Understanding
+> Studio with auto-deployment enabled, clone the code, and set `FOUNDRY_ENDPOINT`, `FOUNDRY_KEY`,
+> and `ANALYZER_NAME` in `Python/.env`. Then, from the
+> `Python` folder, verify you're ready:
+
+```
+python ../setup/check_env.py --task 2
+```
+
+> **Continuing from a previous task?** If you just finished Task 1, your Foundry resource and
+> Content Understanding connection are already set up — you only need the starter code and
+> `.env` steps from [Getting started](A0-getting-started.md). You do **not** need any analyzer
+> you built in the portal: this task creates its own analyzer from code.
+
+---
+
+Building analyzers in a portal is great for designing them. It's no good for running them a
+thousand times a day. Fabrikam Logistics reps come back from trade shows with a stack of scanned
+contact cards, and somebody has to get those into the CRM. In this task you'll create a Content
+Understanding analyzer **from code** and then call it **from code**, so the whole thing can run
+unattended.
+
+<style>
+/* "Ask Rani" just-in-time concept blocks */
+details.concept { margin:.6rem 0 1rem; }
+details.concept > summary { display:inline-block; cursor:pointer; list-style:none;
+  font-size:.85em; font-weight:600; color:#0b6a8f; background:#0b6a8f12;
+  border:1px solid #0b6a8f33; border-radius:999px; padding:.2em .7em; }
+details.concept > summary::-webkit-details-marker { display:none; }
+details.concept > summary::before { content:"Ask Rani: "; font-weight:700; }
+details.concept > summary:hover { background:#0b6a8f; color:#fff; border-color:#0b6a8f; }
+details.concept[open] > summary { border-bottom-left-radius:0; border-bottom-right-radius:0; }
+details.concept .concept-body { border:1px solid #0b6a8f33; border-top:none;
+  border-radius:0 8px 8px 8px; padding:.6rem .9rem; background:#0b6a8f08; font-size:.95em; }
+</style>
+
+<details markdown="1" class="concept">
+<summary>Why does everything return a "poller"?</summary>
+<div class="concept-body" markdown="1">
+
+Creating an analyzer and analyzing a file are both **long-running operations** — they take longer
+than a single HTTP request should wait for. So the service accepts the request, returns
+immediately, and gives you a handle to check on it.
+
+In the Python SDK that handle is an `LROPoller`. You call `.result()` on it, and the SDK does the
+polling loop for you and hands back the finished result. That's why you'll see this shape twice
+in this task:
+
+```python
+poller = client.begin_something(...)
+result = poller.result()
+```
+
+You never write a retry loop yourself.
+
+</div>
+</details>
+
+Open the `Python` folder and activate the virtual environment from
+[Getting started](A0-getting-started.md) (`.\labenv\Scripts\Activate.ps1`), then continue below.
+
+### Review the analyzer schema
+
+1. In the VS Code Explorer pane, open the **contact-card.json** file and review its contents.
+
+    This is the same kind of schema you built by clicking in Task 1 — just written directly as
+    JSON. It specifies the fields to extract (`Company`, `Name`, `Title`, `Email`, `Phone`), the
+    base analyzer to build on, and the models to use.
+
+    > **Note**: The `models` block pins `gpt-5.2` for completion and `text-embedding-3-large` for embedding. If your Foundry resource doesn't have those deployments, change them to models you do have. You can see your deployments in the Foundry portal under **Build > Deployments**.
+
+### Create the analyzer
+
+1. Open the **create-analyzer.py** file in VS Code.
+
+1. Review the code, which:
+    - Imports the `ContentUnderstandingClient` and `AzureKeyCredential` from the [Azure Content Understanding SDK](https://learn.microsoft.com/python/api/overview/azure/ai-contentunderstanding-readme).
+    - Loads the analyzer schema from the **contact-card.json** file.
+    - Retrieves the endpoint, key, and analyzer name from the environment configuration file.
+    - Calls a function named **create_analyzer**, which is currently not implemented.
+
+1. In the **create_analyzer** function, find the comment **TODO: Create a Content Understanding analyzer** and replace the comment block and the `pass` statement with the following code (being careful to maintain the correct indentation):
+
+    ```python
+    # Create a Content Understanding analyzer
+    print(f"Creating {analyzer}")
+
+    # Create the Content Understanding client
+    client = ContentUnderstandingClient(
+        endpoint=endpoint,
+        credential=AzureKeyCredential(key)
+    )
+
+    # Parse the schema JSON into a ContentAnalyzer object
+    analyzer_definition = json.loads(schema)
+
+    # Create the analyzer using the SDK (long-running operation)
+    poller = client.begin_create_analyzer(
+        analyzer_id=analyzer,
+        resource=analyzer_definition,
+        allow_replace=True
+    )
+
+    # Wait for the operation to complete
+    result = poller.result()
+    print(f"Analyzer '{analyzer}' created successfully.")
+    print(f"Status: {result['status'] if isinstance(result, dict) else 'Succeeded'}")
+    ```
+
+1. Review the code you added, which:
+    - Creates a `ContentUnderstandingClient` instance with the endpoint and API key.
+    - Parses the analyzer schema JSON.
+    - Uses `begin_create_analyzer` to start the long-running operation that creates the analyzer.
+    - Calls `.result()` to wait for the operation to complete.
+
+    > **Note**: `allow_replace=True` means re-running the script overwrites an existing analyzer with the same name instead of failing — handy while you're iterating on a schema.
+
+1. Save the file (**Ctrl+S**).
+1. In the VS Code terminal (with the virtual environment activated and the **Python** folder as your working directory), run the code:
+
+    ```
+    python create-analyzer.py
+    ```
+
+1. Review the output, which should indicate that the analyzer has been created.
+
+### Analyze content with the analyzer
+
+Now consume the analyzer you just created from a client application.
+
+1. In VS Code, open the **read-card.py** file.
+
+1. Review the code, which:
+    - Imports the `ContentUnderstandingClient` and `AzureKeyCredential` from the SDK.
+    - Identifies the image file to be analyzed, defaulting to **biz-card-1.png**.
+    - Resolves a bare file name against the shared `Instructions/Exercises/media` folder, so the sample cards that ship with the repo are used in place.
+    - Retrieves the endpoint, key, and analyzer name from the environment configuration file.
+    - Calls a function named **analyze_card**, which is currently not implemented.
+
+1. In the **analyze_card** function, find the comment **TODO: Use Content Understanding to analyze the image** and replace the comment block and the `pass` statement with the following code (being careful to maintain the correct indentation):
+
+    ```python
+    # Use Content Understanding to analyze the image
+    print(f"Analyzing {image_file}")
+
+    # Create the Content Understanding client
+    client = ContentUnderstandingClient(
+        endpoint=endpoint,
+        credential=AzureKeyCredential(key)
+    )
+
+    # Read the image data
+    with open(image_file, "rb") as file:
+        image_data = file.read()
+
+    # Submit the image for analysis
+    print("Submitting request...")
+    poller = client.begin_analyze_binary(
+        analyzer_id=analyzer,
+        binary_input=image_data
+    )
+
+    # Wait for the analysis to complete
+    result = poller.result()
+    print("Analysis succeeded:\n")
+
+    # Save JSON results to a file
+    output_file = "results.json"
+    with open(output_file, "w") as json_file:
+        json.dump(dict(result), json_file, indent=4, default=str)
+        print(f"Response saved in {output_file}\n")
+
+    # Iterate through the contents and extract fields
+    for content in result.contents:
+        if hasattr(content, 'fields') and content.fields:
+            for field_name, field_data in content.fields.items():
+                value = field_data.value if hasattr(field_data, 'value') else None
+                print(f"{field_name}: {value}")
+    ```
+
+1. Review the code you added, which:
+    - Creates a `ContentUnderstandingClient` instance.
+    - Reads the content of the image file as bytes.
+    - Calls `begin_analyze_binary` to submit the image to the analyzer.
+    - Calls `.result()` to wait for and retrieve the analysis results.
+    - Saves the JSON response and parses the extracted fields.
+
+1. Save the file (**Ctrl+S**).
+1. In the VS Code terminal, run the code:
+
+    ```
+    python read-card.py biz-card-1.png
+    ```
+
+1. Review the output, which should show the values for the fields on the following card:
+
+    ![A scanned contact card showing a name, job title, company, email address, and phone number.](../media/biz-card-1.png)
+
+1. Run the program again with a different card:
+
+    ```
+    python read-card.py biz-card-2.png
+    ```
+
+1. Review the results, which should reflect the values on this card:
+
+    ![A second scanned contact card in a different layout, showing a name, job title, company, email address, and phone number.](../media/biz-card-2.png)
+
+    Notice that the two cards have completely different layouts, and the same analyzer handled
+    both. You never told it where on the card to look — only what you wanted.
+
+1. To view the full JSON response that was returned, open the **results.json** file in VS Code, or run the following command in the terminal:
+
+    ```
+    type results.json
+    ```
+
+> ✅ **Checkpoint**: You've created a Content Understanding analyzer from a JSON schema and called
+> it from a client application. Same service as Task 1, no portal involved — which is what makes
+> it automatable.
+
+When you're finished, enter `deactivate` to exit the virtual environment.
+
+---
+
+**Next (optional):** [Task 3 — Extract invoice data with a prebuilt model](A3-extract-invoice-data-with-a-prebuilt-model.md) · [Task 4 — Train a custom extraction model](A4-train-a-custom-extraction-model.md)

--- a/Instructions/Exercises/Consolidated/A3-extract-invoice-data-with-a-prebuilt-model.md
+++ b/Instructions/Exercises/Consolidated/A3-extract-invoice-data-with-a-prebuilt-model.md
@@ -1,0 +1,185 @@
+---
+lab:
+    title: 'Task 3 – Extract invoice data with a prebuilt model'
+    description: 'Use Azure Document Intelligence prebuilt models to extract text and structured invoice fields with no schema and no training: try Read in the Studio, then call prebuilt-invoice from Python.'
+    level: 300
+    concepts: 'Document Intelligence, prebuilt models, OCR, confidence scores'
+    islab: true
+    status: 'draft'
+---
+
+# Task 3 — Extract invoice data with a prebuilt model
+
+*Part of the **Extract information from business content** lab. New here? Start with [Getting started](A0-getting-started.md).*
+
+> **Set up (start here):** This task needs a **Document Intelligence** resource and the starter
+> code — it does **not** need a Foundry resource or anything you built in Tasks 1 or 2. If you
+> haven't already, complete [Getting started](A0-getting-started.md) to create your Document
+> Intelligence resource, clone the code, and set `DOC_INTELLIGENCE_ENDPOINT` and
+> `DOC_INTELLIGENCE_KEY` in `Python/.env`. Then, from the
+> `Python` folder, verify you're ready:
+
+```
+python ../setup/check_env.py --task 3
+```
+
+> **Continuing from a previous task?** If you just finished an earlier task in the same `Python`
+> folder, your virtual environment and `.env` are already in place — you only need to add the
+> two `DOC_INTELLIGENCE_*` values, which come from a **different** resource than the
+> `FOUNDRY_*` ones. Create the Document Intelligence resource per
+> [Getting started](A0-getting-started.md) if you skipped that section.
+
+---
+
+In Tasks 1 and 2, you told Content Understanding what fields you wanted. Now try the opposite
+approach. Fabrikam Logistics processes thousands of invoices, and "invoice" is a document type
+the world already agrees on — so Azure Document Intelligence ships a model that already knows
+what a vendor name and an invoice total are. No schema. No training. Just call it.
+
+<style>
+/* "Ask Rani" just-in-time concept blocks */
+details.concept { margin:.6rem 0 1rem; }
+details.concept > summary { display:inline-block; cursor:pointer; list-style:none;
+  font-size:.85em; font-weight:600; color:#0b6a8f; background:#0b6a8f12;
+  border:1px solid #0b6a8f33; border-radius:999px; padding:.2em .7em; }
+details.concept > summary::-webkit-details-marker { display:none; }
+details.concept > summary::before { content:"Ask Rani: "; font-weight:700; }
+details.concept > summary:hover { background:#0b6a8f; color:#fff; border-color:#0b6a8f; }
+details.concept[open] > summary { border-bottom-left-radius:0; border-bottom-right-radius:0; }
+details.concept .concept-body { border:1px solid #0b6a8f33; border-top:none;
+  border-radius:0 8px 8px 8px; padding:.6rem .9rem; background:#0b6a8f08; font-size:.95em; }
+</style>
+
+<details markdown="1" class="concept">
+<summary>What is a confidence score, and what should I do with it?</summary>
+<div class="concept-body" markdown="1">
+
+Every field a Document Intelligence model returns comes with a **confidence** value between 0
+and 1 — how sure the model is that it read that field correctly.
+
+This is the practical difference between a demo and a production pipeline. Real invoice
+processing sets a threshold: above it, post the value automatically; below it, route the document
+to a human to check. You get that for free with Document Intelligence, which is a big part of why
+it's used for high-volume, money-touching documents.
+
+Watch the confidence values in the output of this task — they aren't all the same.
+
+[Learn more →](https://learn.microsoft.com/azure/ai-services/document-intelligence/overview)
+
+</div>
+</details>
+
+## Use the Read model in the Studio
+
+First, see what pure OCR gives you — including a detail that matters for a freight forwarder
+handling paperwork in several languages.
+
+1. In a web browser, navigate to **Document Intelligence Studio** at `https://documentintelligence.ai.azure.com/studio` and sign in with your Azure credentials.
+1. On the Studio home page, under **Document analysis**, select the **Read** tile.
+1. In the list of documents on the left, select **read-german.pdf**.
+1. On the top toolbar, select **Analyze options**, then enable the **Language** check-box (under **Optional detection**) in the **Analyze options** pane and select **Save**.
+1. At the top-left, select **Run Analysis**.
+1. When the analysis is complete, the text extracted from the image is shown on the right in the **Content** tab. Review this text and compare it to the text in the original image for accuracy.
+1. Select the **Result** tab. This tab displays the extracted JSON.
+1. Scroll to the bottom of the JSON in the **Result** tab. Notice that the read model has detected the language of each span, indicated by `locale`. Most spans are in German (language code `de`), but you can find other language codes in the spans (for example, English — language code `en` — in one of the first spans).
+
+    Read gives you *text*. What it doesn't give you is meaning: nothing here says "this number is
+    the total". That's the job of the prebuilt invoice model, next.
+
+## Analyze an invoice with a prebuilt model using the Python SDK
+
+1. In the [Azure portal](https://portal.azure.com), find the Document Intelligence resource you created. Under **Resource Management**, select **Keys and Endpoint**, and confirm the **Endpoint** and **Key** match what you put in your `.env`.
+
+1. Open the `Python` folder and activate the virtual environment from [Getting started](A0-getting-started.md):
+
+    ```
+    .\labenv\Scripts\Activate.ps1
+    ```
+
+This is the sample invoice that your code will analyze:
+
+![Screenshot showing a sample invoice document.](../media/sample-invoice.png)
+
+1. In VS Code, open the **document-analysis.py** file.
+
+1. Review the code. Notice that it already sets `fileModelId = "prebuilt-invoice"` — that string is the entire "schema" for this task.
+
+1. In the code file, find the comment **TODO: Add references** and replace it with the following code:
+
+    ```python
+    # Add references
+    from azure.core.credentials import AzureKeyCredential
+    from azure.ai.documentintelligence import DocumentIntelligenceClient
+    from azure.ai.documentintelligence.models import AnalyzeDocumentRequest
+    ```
+
+1. Find the comment **TODO: Create the client** and replace it with the following code (being careful to maintain the correct indentation):
+
+    ```python
+    # Create the client
+    document_analysis_client = DocumentIntelligenceClient(
+        endpoint=endpoint, credential=AzureKeyCredential(key)
+    )
+    ```
+
+1. Find the comment **TODO: Analyze the invoice** and replace it with the following code:
+
+    ```python
+    # Analyze the invoice
+    poller = document_analysis_client.begin_analyze_document(
+        fileModelId,
+        AnalyzeDocumentRequest(url_source=fileUri),
+        locale=fileLocale
+    )
+    ```
+
+1. Find the comment **TODO: Display invoice information to the user** and replace it with the following code:
+
+    ```python
+    # Display invoice information to the user
+    result = poller.result()
+
+    for document in result.documents:
+
+        vendor_name = document.fields.get("VendorName")
+        if vendor_name:
+            print(f"\nVendor Name: {vendor_name.get('valueString')}, with confidence {vendor_name.get('confidence')}.")
+
+        customer_name = document.fields.get("CustomerName")
+        if customer_name:
+            print(f"Customer Name: {customer_name.get('valueString')}, with confidence {customer_name.get('confidence')}.")
+
+        invoice_total = document.fields.get("InvoiceTotal")
+        if invoice_total:
+            amount = invoice_total.get("valueCurrency", {})
+            print(f"Invoice Total: {amount.get('currencySymbol', '$')}{amount.get('amount')}, with confidence {invoice_total.get('confidence')}.")
+    ```
+
+1. Review the code you added, which:
+    - Creates a `DocumentIntelligenceClient` with your endpoint and credentials.
+    - Uses the `prebuilt-invoice` model to analyze the document from a URL.
+    - Iterates through the results and prints the vendor name, customer name, and invoice total — each with its confidence score.
+
+1. Save the file (**Ctrl+S**).
+1. In the VS Code terminal, run the application:
+
+    ```
+    python document-analysis.py
+    ```
+
+1. Review the output. The program should display the vendor name, customer name, and invoice total with confidence levels. Compare the values with the sample invoice shown above.
+
+    Note how much you *didn't* have to do: no schema, no field descriptions, no training data. For
+    a document type that's standard across the industry, the prebuilt model is simply the fastest
+    correct answer.
+
+> ✅ **Checkpoint**: You've extracted structured invoice fields with a prebuilt Document
+> Intelligence model and seen the confidence score attached to each one. Prebuilt models cover
+> common document types — but Fabrikam Logistics also has forms that no prebuilt model has ever
+> seen. That's Task 4.
+
+When you're finished, enter `deactivate` to exit the virtual environment.
+
+---
+
+**Next (optional):** [Task 4 — Train a custom extraction model](A4-train-a-custom-extraction-model.md)

--- a/Instructions/Exercises/Consolidated/A4-train-a-custom-extraction-model.md
+++ b/Instructions/Exercises/Consolidated/A4-train-a-custom-extraction-model.md
@@ -1,0 +1,180 @@
+---
+lab:
+    title: 'Task 4 – Train a custom extraction model'
+    description: 'Train a custom Azure Document Intelligence extraction model on labeled Fabrikam Logistics forms, then call it from Python to extract fields no prebuilt model knows about.'
+    level: 300
+    concepts: 'Document Intelligence, custom extraction models, training data, SAS URIs'
+    islab: true
+    status: 'draft'
+---
+
+# Task 4 — Train a custom extraction model
+
+*Part of the **Extract information from business content** lab. New here? Start with [Getting started](A0-getting-started.md).*
+
+> **What you need:** a **Document Intelligence** resource, the starter code, and a Bash shell
+> with the Azure CLI signed in (for the training-data upload script). This task does **not** need
+> a Foundry resource or anything you built in Tasks 1, 2, or 3. If you haven't already, complete
+> [Getting started](A0-getting-started.md) to create your Document Intelligence resource, clone
+> the code, and set `DOC_INTELLIGENCE_ENDPOINT` and `DOC_INTELLIGENCE_KEY` in `Python/.env`.
+> You'll fill in `CUSTOM_MODEL_ID` partway through this task, once you've trained the model. Then, from the `Python` folder, verify you're ready:
+
+```
+python ../setup/check_env.py --task 4
+```
+
+> `CUSTOM_MODEL_ID` will show as MISSING until you train the model below — that's expected.
+
+> **Continuing from a previous task?** If you just finished Task 3, you already have everything
+> except the trained model itself: same resource, same `.env`, same virtual environment. Skip
+> straight to **Prepare training data** below.
+
+---
+
+Prebuilt models are unbeatable for standard documents. But Fabrikam Logistics also runs on forms
+that only Fabrikam Logistics uses — internal transfer dockets whose layout no prebuilt model has
+ever seen. For those, you train your own model on a handful of labeled examples.
+
+<style>
+/* "Ask Rani" just-in-time concept blocks */
+details.concept { margin:.6rem 0 1rem; }
+details.concept > summary { display:inline-block; cursor:pointer; list-style:none;
+  font-size:.85em; font-weight:600; color:#0b6a8f; background:#0b6a8f12;
+  border:1px solid #0b6a8f33; border-radius:999px; padding:.2em .7em; }
+details.concept > summary::-webkit-details-marker { display:none; }
+details.concept > summary::before { content:"Ask Rani: "; font-weight:700; }
+details.concept > summary:hover { background:#0b6a8f; color:#fff; border-color:#0b6a8f; }
+details.concept[open] > summary { border-bottom-left-radius:0; border-bottom-right-radius:0; }
+details.concept .concept-body { border:1px solid #0b6a8f33; border-top:none;
+  border-radius:0 8px 8px 8px; padding:.6rem .9rem; background:#0b6a8f08; font-size:.95em; }
+</style>
+
+<details markdown="1" class="concept">
+<summary>Why only five training forms?</summary>
+<div class="concept-body" markdown="1">
+
+A **custom template** model learns from *position*: it expects each field to appear in roughly
+the same place on every document. Because it's learning a fixed layout rather than a general
+concept, it needs very little data — five labeled examples is the documented minimum, and for a
+consistent form it's often enough.
+
+That's also its limitation. If your documents vary a lot in structure, a template model struggles,
+and you'd reach for a custom **neural** model (more tolerant of variation, needs more data) or
+back to Content Understanding.
+
+The labeling itself is what those `.labels.json` and `.ocr.json` files next to each image are —
+they've been prepared for you here so you can skip straight to training.
+
+[Learn more →](https://learn.microsoft.com/azure/ai-services/document-intelligence/overview)
+
+</div>
+</details>
+
+### Prepare training data
+
+A setup script creates a storage account and uploads the labeled sample forms for training.
+
+1. In the VS Code terminal, navigate to the lab's setup folder. It's a sibling of the `Python` folder your terminal opens in:
+
+    ```
+    cd ../setup
+    ```
+
+1. In VS Code, open the **upload-training-forms.sh** file.
+
+1. Review the commands in the script. It will:
+    - Create a storage account in your Azure resource group
+    - Upload the labeled training forms to a container named `sampleforms`
+    - Print a Shared Access Signature (SAS) URI
+
+    > **Note**: The script uses the labeled training forms that already ship with this repo, so nothing is duplicated. If you moved them, set the `SAMPLE_FORMS_DIR` environment variable to their folder before running the script.
+
+1. Modify the **subscription_id**, **resource_group**, and **location** variable declarations with the appropriate values for the subscription, resource group, and location where you deployed the Document Intelligence resource.
+
+    > **Important**: For your **location** string, use the code format (for example, `eastus` for "East US"). You can find this in the **JSON View** of your resource group in the Azure portal.
+
+    If the **expiry_date** variable is in the past, update it to a future date.
+
+1. Save the file (**Ctrl+S**).
+1. To run the setup script, you need a Bash shell, and you must be signed in to your Azure account. Use one of the following:
+    - **Azure Cloud Shell**: In the [Azure portal](https://portal.azure.com), open a Cloud Shell (Bash), navigate to the folder, and run `./upload-training-forms.sh`.
+    - **VS Code terminal (with WSL or Git Bash on Windows)**: Run `bash upload-training-forms.sh`.
+
+1. When the script completes, review the displayed output and **note the storage account name** — you'll select it when you create the training project.
+1. In the Azure portal, refresh your resource group and verify that the storage account was created. Open the storage account and, in **Storage browser**, expand **Blob containers** and select the **sampleforms** container to confirm the files were uploaded.
+
+### Train the model in Document Intelligence Studio
+
+Now use the training forms to build a custom extraction model.
+
+1. Open a new browser tab and navigate to **Document Intelligence Studio** at `https://documentintelligence.ai.azure.com/studio`.
+1. Scroll down to the **Custom models** section and select the **Custom extraction model** tile.
+1. If prompted, sign in with your Azure credentials.
+1. If asked which Azure Document Intelligence resource to use, select the subscription and resource name you used when you created the resource.
+1. Under **My Projects**, create a new project with the following configuration:
+
+    - **Enter project details**:
+        - **Project name**: *A valid name for your project*
+    - **Configure service resource**:
+        - **Subscription**: *Your Azure subscription*
+        - **Resource group**: *The resource group of your Document Intelligence resource*
+        - **Document Intelligence resource**: *Your Document Intelligence resource* (select the *Set as default* option and use the default API version)
+    - **Connect training data source**:
+        - **Subscription**: *Your Azure subscription*
+        - **Resource group**: *Your resource group*
+        - **Storage account**: *The storage account created by the setup script* (select the *Set as default* option, select the `sampleforms` blob container, and leave the folder path blank)
+
+1. When your project is created, at the top right of the page select **Train** to train your model. Use the following configuration:
+    - **Model ID**: *A valid name for your model — note it down, you'll need it in a moment*
+    - **Build Mode**: Template
+1. Select **Go to Models**.
+1. Training may take some time. Wait until the model status shows **succeeded**.
+
+### Test the custom model with the Python SDK
+
+1. In VS Code, open the **.env** file in **Labfiles/A-extract-information-from-business-content/Python** and set `CUSTOM_MODEL_ID` to the **Model ID** you specified when training your model. Save the file (**Ctrl+S**).
+
+1. In the VS Code terminal, return to the `Python` folder and activate the virtual environment if it isn't already active:
+
+    ```
+    cd ../Python
+    .\labenv\Scripts\Activate.ps1
+    ```
+
+1. Confirm you're now ready:
+
+    ```
+    python ../setup/check_env.py --task 4
+    ```
+
+    All four keys should show `OK`.
+
+1. In VS Code, open the **test-model.py** file.
+
+1. Review the code, which uses the [azure-ai-documentintelligence](https://learn.microsoft.com/python/api/overview/azure/ai-documentintelligence-readme) SDK. Notice that it:
+    - Reads your endpoint, key, and `CUSTOM_MODEL_ID` from `.env`, so it needs no changes to work with *your* model.
+    - References a test form hosted in the GitHub repo — a form the model was **not** trained on.
+    - Creates a `DocumentIntelligenceClient`, submits the form for analysis with your custom model, and prints each extracted field with its confidence.
+
+1. In the VS Code terminal, run the program:
+
+    ```
+    python test-model.py
+    ```
+
+1. Review the output. The program should display the field names and values extracted from the test form, such as `Merchant`, `CompanyPhoneNumber`, and the other fields defined in the training labels.
+
+    ![An image of the form used to test the custom model.](../media/Form_1.jpg)
+
+    Compare this to Task 3: there, the field names came from Microsoft's invoice model. Here, they
+    came from *your* labels. That's the whole difference between prebuilt and custom.
+
+> ✅ **Checkpoint**: You've trained a custom Document Intelligence extraction model on labeled
+> forms and called it from Python. Between this and the previous tasks you've now covered all
+> three extraction strategies: generative (Content Understanding), prebuilt, and trained.
+
+When you're finished, enter `deactivate` to exit the virtual environment.
+
+---
+
+**Next:** You've completed the optional tasks. Head back to the [lab overview](A-extract-information-from-business-content.md) for a summary and clean-up steps — or carry on to [Make extracted information searchable](B-make-extracted-information-searchable.md), where you make everything you've extracted findable and answerable.

--- a/Instructions/Exercises/Consolidated/B-make-extracted-information-searchable.md
+++ b/Instructions/Exercises/Consolidated/B-make-extracted-information-searchable.md
@@ -1,0 +1,159 @@
+---
+lab:
+    title: 'Make extracted information searchable'
+    description: 'Turn the Fabrikam Logistics document library into something people can actually query: build an AI-enriched search index in the portal, then a code-driven RAG pipeline that extracts, embeds, indexes, and answers questions - and keeps itself up to date. A modular lab you can complete end to end or one task at a time.'
+    level: 300
+    concepts: 'Azure AI Search, AI enrichment, indexers, vector search, RAG, continuous ingestion'
+    duration: 40
+    islab: true
+    status: 'draft'
+---
+
+# Make extracted information searchable
+
+**Difficulty** ▰▰▰▱▱ **L300**  (filled bars out of 5; **L100** beginner → **L500** expert)
+
+Extracting information is only half the job. A folder full of perfectly extracted fields that
+nobody can query is still a folder nobody uses. In this lab you'll build the retrieval layer for
+**Fabrikam Logistics** — first with a no-code indexer, then with a pipeline you write yourself
+that keeps answering questions as new documents arrive.
+
+<style>
+/* "Ask Rani" just-in-time concept blocks */
+details.concept { margin:.6rem 0 1rem; }
+details.concept > summary { display:inline-block; cursor:pointer; list-style:none;
+  font-size:.85em; font-weight:600; color:#0b6a8f; background:#0b6a8f12;
+  border:1px solid #0b6a8f33; border-radius:999px; padding:.2em .7em; }
+details.concept > summary::-webkit-details-marker { display:none; }
+details.concept > summary::before { content:"Ask Rani: "; font-weight:700; }
+details.concept > summary:hover { background:#0b6a8f; color:#fff; border-color:#0b6a8f; }
+details.concept[open] > summary { border-bottom-left-radius:0; border-bottom-right-radius:0; }
+details.concept .concept-body { border:1px solid #0b6a8f33; border-top:none;
+  border-radius:0 8px 8px 8px; padding:.6rem .9rem; background:#0b6a8f08; font-size:.95em; }
+</style>
+
+<details markdown="1" class="concept">
+<summary>What is RAG, and why does it need a search index?</summary>
+<div class="concept-body" markdown="1">
+
+**Retrieval-augmented generation (RAG)** means: before you ask a language model a question, go
+and fetch the most relevant bits of your own content, and paste them into the prompt as context.
+The model then answers from *your* data instead of from whatever it happened to memorize.
+
+That "go and fetch" step is a search problem, which is why RAG solutions are built on a search
+index. And it's why the quality of your index sets the ceiling on the quality of your answers —
+if retrieval returns the wrong three chunks, no model can rescue the answer.
+
+[Learn more →](https://learn.microsoft.com/azure/search/retrieval-augmented-generation-overview)
+
+</div>
+</details>
+
+**Your scenario:** you work at **Fabrikam Logistics**, a freight-forwarding company. The company
+has years of reference documents — destination and route guides, operating notes, service
+information — sitting in a document library. Staff know the answers are in there somewhere, and
+that's exactly the problem. Your job is to make that library searchable, then answerable, then
+self-maintaining.
+
+You'll start with the **Core** task, which gets you a working AI-enriched search index and a
+client app that queries it. From there, a set of **Optional** tasks builds a full RAG pipeline on
+top.
+
+> **Note**: Some of the technologies used in this exercise are in preview or in active
+> development. You may experience some unexpected behavior, warnings, or errors.
+
+## What you'll learn
+
+By completing the **Core** task of this exercise, you'll be able to:
+
+- **Build an AI-enriched search index** with Azure AI Search — attach skills that pull key
+  phrases, people, and locations out of your documents during indexing, then query the result
+  from Search explorer and from a Python client app.
+
+The **Optional** tasks let you additionally:
+
+- **Build an ingestion pipeline in code** that extracts content with Content Understanding,
+  chunks it, embeds it with Azure OpenAI, and indexes it for vector search.
+- **Answer questions with a RAG agent** that combines keyword and vector retrieval and grounds a
+  chat model in what it finds.
+- **Keep the index fresh automatically**, running the pipeline in watch mode so new documents
+  become answerable without anyone reprocessing anything.
+
+## How this lab is organized
+
+This lab is **modular**. Each task is written to be completed **on its own, starting fresh** —
+so you can pick a single task and do just that one. Every task also shares one starter folder,
+one virtual environment, and one `.env`, so if you'd rather work straight through, you can.
+
+1. **Start with [Getting started](B0-getting-started.md)** — create your Azure AI Search resource
+   (and, for the optional tasks, a Microsoft Foundry resource and storage account), get the
+   starter code and sample documents, and set up your `.env`. Every task begins here; if you're
+   doing the whole lab in one sitting, you only need to do this once.
+2. **Do any task.** Each task lists the setup it needs so you can start it independently. If
+   you're moving straight from the previous task, a short *"Continuing from a previous task?"*
+   note at the top lets you skip the repeated setup and keep going.
+
+## Lab at a glance
+
+Complete the **Core** task first (about **40 minutes**) — it ends with a queryable, AI-enriched
+index. Then expand any **Optional** tasks that interest you. The full lab, including all optional
+tasks, takes about **2 hours 10 minutes**.
+
+| Section | Task | Difficulty | Time |
+| --- | --- | --- | --- |
+| **Core** | [Task 1 – Build a knowledge mining index](B1-build-a-knowledge-mining-index.md) | ▰▰▱▱▱ L200 | ~40 min |
+| *Optional* | [Task 2 – Build a RAG ingestion pipeline](B2-build-a-rag-ingestion-pipeline.md) | ▰▰▰▱▱ L300 | ~30 min |
+| *Optional* | [Task 3 – Answer questions with a RAG agent](B3-answer-questions-with-a-rag-agent.md) | ▰▰▰▱▱ L300 | ~20 min |
+| *Optional* | [Task 4 – Keep the index fresh with watch mode](B4-keep-the-index-fresh-with-watch-mode.md) | ▰▰▰▰▱ L400 | ~40 min |
+
+**Choosing your path** — pick the tasks that fit the time you have:
+
+- **Core only (~40 min):** do Task 1. You'll have a working AI-enriched index and a client app.
+- **A working RAG solution (~1h 30m):** add **Task 2** and **Task 3** — index your own content in
+  code, then ask questions of it.
+- **Everything (~2h 10m):** add **Task 4**, which turns the pipeline into something that keeps
+  running.
+
+> **Note**: Tasks 2, 3, and 4 build on each other and are best done in order. Each one still
+> states exactly what it needs, so you can start at Task 3 or 4 if you've already got an index
+> populated.
+
+## Two ways to build an index
+
+The lab deliberately shows both, because real solutions choose between them:
+
+- In **Task 1**, Azure AI Search does everything. You point the **Import data** wizard at a blob
+  container, tick some AI skills, and it crawls, enriches, and indexes on a schedule. No code.
+  You get an index full of extracted key phrases, people, and locations.
+- In **Tasks 2–4**, *you* do everything. Your code extracts with Content Understanding, chunks
+  the content, generates embeddings, and pushes documents into an index you defined. It's more
+  work — and it's the only way to control chunking, add vector search, and decide exactly when
+  and what gets reprocessed.
+
+The first is how you get value in an afternoon. The second is how you build a RAG system you can
+tune.
+
+## Summary
+
+Across this lab you:
+
+- Built an **AI-enriched Azure AI Search index** with an indexer and skills, and queried it from
+  Search explorer and a Python client.
+- (Optionally) built an **ingestion pipeline** that extracts, chunks, embeds, and indexes
+  documents in code.
+- (Optionally) answered questions with a **RAG agent** using hybrid keyword + vector retrieval.
+- (Optionally) ran the pipeline in **watch mode** so new documents become answerable
+  automatically.
+
+Together these take you from "the answer is in a PDF somewhere" to "ask a question, get a
+grounded answer, including from the document that arrived five minutes ago."
+
+If you haven't already extracted structured fields from your content, see
+[Extract information from business content](A-extract-information-from-business-content.md).
+
+## Clean up
+
+If you're finished, delete the resources you created to avoid unnecessary Azure costs.
+
+1. In the [Azure portal](https://portal.azure.com), navigate to the resource group that contains your Azure AI Search, storage, and Foundry resources.
+1. On the toolbar, select **Delete resource group**, enter the resource group name, and confirm.

--- a/Instructions/Exercises/Consolidated/B0-getting-started.md
+++ b/Instructions/Exercises/Consolidated/B0-getting-started.md
@@ -1,0 +1,197 @@
+---
+lab:
+    title: 'Getting started: set up your environment'
+    description: 'Shared setup for the Make extracted information searchable lab: create an Azure AI Search resource, storage, and a Microsoft Foundry resource, get the starter code and sample documents, and configure your environment. Complete this once before any task.'
+    level: 300
+    concepts: 'environment setup, Azure AI Search, Microsoft Foundry resource'
+    status: 'draft'
+---
+
+# Getting started
+
+This page sets up everything the **Make extracted information searchable** lab needs. **Every
+task begins here** — complete this page first. Each task is written so you can then do it on its
+own; if you're working through the whole lab in one sitting, you only need to do this setup once.
+
+**Your scenario:** you work at **Fabrikam Logistics**, a freight-forwarding company. Across the
+lab you'll turn the company's reference document library into a searchable, answerable, and
+self-updating knowledge base.
+
+> **Note**: Some of the technologies used in this lab are in preview or in active development.
+> You may experience some unexpected behavior, warnings, or errors.
+
+## Prerequisites
+
+Before starting, ensure you have:
+
+- An [Azure subscription](https://azure.microsoft.com/free/) with sufficient permissions and quota to provision Azure AI resources
+- [Visual Studio Code](https://code.visualstudio.com/) installed on your local machine
+- [Python 3.11](https://www.python.org/downloads/) or later installed\*
+- [Git](https://git-scm.com/downloads) installed on your local machine
+- Basic familiarity with Python
+
+> \* The Azure SDK for Python supports Python 3.9 or later. This lab was tested with Python 3.13.
+
+## What each task needs
+
+Create only what you need. Everything goes in **one resource group**, in **one region**.
+
+| Resource | Needed by |
+| --- | --- |
+| Azure AI Search | All tasks |
+| Azure Storage account | Task 1 (holds the documents the indexer crawls) |
+| Microsoft Foundry resource with model deployments | Tasks 2, 3, 4 |
+
+## Create an Azure AI Search resource
+
+1. In a web browser, open the [Azure portal](https://portal.azure.com) at `https://portal.azure.com` and sign in with your Azure credentials.
+1. Select **&#65291;Create a resource**, search for `Azure AI Search`, and create an **Azure AI Search** resource with the following settings:
+    - **Subscription**: *Your Azure subscription*
+    - **Resource group**: *Create or select a resource group*
+    - **Service name**: *A valid unique name for your search resource*
+    - **Location**: *Any available location — note it, and use the same one for everything else*
+    - **Pricing tier**: Free (*or Basic if Free isn't available*)
+1. Wait for deployment to complete, and then go to the deployed resource.
+1. Review the **Overview** page. Here you can create, test, manage, and monitor the components of a search solution.
+
+    > **Note**: The Free tier is enough for this lab, but it limits you to a small number of indexes and documents. If you plan to run Task 1 *and* Tasks 2-4 on a Free-tier service, you'll be creating two indexes — that's within the Free limit.
+
+## Create a storage account (Task 1 only)
+
+Skip this if you're only doing Tasks 2, 3, and 4.
+
+1. Return to the Azure portal home page and create a **Storage account** resource with the following settings:
+    - **Subscription**: *Your Azure subscription*
+    - **Resource group**: *The same resource group as your Azure AI Search resource*
+    - **Storage account name**: *A valid globally unique name*
+    - **Region**: *The same region as your Azure AI Search resource*
+    - **Primary service**: Azure Blob Storage or Azure Data Lake Storage Gen 2
+    - **Performance**: Standard
+    - **Redundancy**: Locally-redundant storage (LRS)
+1. Wait for deployment to complete, and then go to the deployed resource.
+
+## Create a Microsoft Foundry resource and project (Tasks 2, 3, 4 only)
+
+Skip this if you're only doing Task 1.
+
+1. In a web browser, open the [Microsoft Foundry portal](https://ai.azure.com) at `https://ai.azure.com` and sign in using your Azure credentials. Close any tips or quick start panes.
+
+    > **Important**: For this lab, you're using the **New** Foundry experience. Make sure the **New Foundry** toggle is on.
+
+1. Select the project name in the upper-left corner, and then select **Create new project**.
+1. Give your project a name and expand **Advanced options** to specify the following settings:
+    - **Subscription**: *Your Azure subscription*
+    - **Resource group**: *The same resource group you've been using*
+    - **Location**: Choose one of the following supported regions:\*
+        - Australia East
+        - East US
+        - East US 2
+        - Japan East
+        - North Europe
+        - South Central US
+        - Southeast Asia
+        - Sweden Central
+        - UK South
+        - West Europe
+        - West US
+        - West US 3
+
+    > \*Azure Content Understanding is available in selected regions. See the [region support documentation](https://learn.microsoft.com/azure/ai-services/content-understanding/language-region-support) for the latest availability.
+
+1. Select **Create** and wait for your project to be created. This creates a project and its parent Foundry resource.
+1. Once created, select the project name at the top of the page, and select **Project details**. On that page, follow the link to the parent resource. **Leave this browser tab open.**
+
+### Connect Content Understanding and deploy models
+
+1. In a new tab, navigate to [Content Understanding Studio](https://contentunderstanding.ai.azure.com/home) at `https://contentunderstanding.ai.azure.com/home` and sign in with your credentials.
+1. Select the settings gear icon on the top navigation bar, and select **+ Add resource**.
+1. Select your subscription and resource group, then select your Foundry resource from the dropdown.
+1. Make sure the **Enable auto-deployment** box is checked, then select **Next** and **Save**.
+1. Wait while the required models deploy.
+1. Back in the Foundry portal, select **Build** > **Deployments** and note the exact names of your **chat** and **embedding** model deployments.
+
+    > **Important**: Deployment names often have a numeric suffix (for example, `gpt-5.2-######`). Copy them exactly — a wrong deployment name is the single most common cause of failures in Tasks 2-4.
+
+## Gather your credentials
+
+You'll need these values for your `.env`:
+
+| Value | Where to find it |
+| --- | --- |
+| **Search endpoint** | Azure AI Search resource > **Overview** > **Url** (for example, `https://your-search.search.windows.net`) |
+| **Search query key** | Azure AI Search resource > **Settings** > **Keys** > query key |
+| **Search admin key** | Azure AI Search resource > **Settings** > **Keys** > primary or secondary admin key |
+| **Foundry endpoint** | Foundry parent resource > **Overview** > **Endpoint** |
+| **Foundry key** | Foundry parent resource > **Resource Management** > **Keys and Endpoint** |
+| **Model deployment names** | Foundry portal > **Build** > **Deployments** |
+
+> **Note**: Azure AI Search creates one default query key for the service. In the Azure portal,
+> this default query key can appear with a blank name. That's expected behavior.
+
+## Get the starter code
+
+1. In VS Code, open the Command Palette (**Ctrl+Shift+P**), run **Git: Clone**, and enter:
+
+    ```
+    https://github.com/microsoftlearning/mslearn-ai-information-extraction
+    ```
+
+1. Open the cloned repo, then **File > Open Folder** and select `mslearn-ai-information-extraction/Labfiles/B-make-extracted-information-searchable/Python`. This single folder holds the code for **every** task in this lab — you use one virtual environment and one `.env` throughout.
+
+1. Right-click **requirements.txt** and choose **Open in Integrated Terminal**. Then create a virtual environment and install packages:
+
+    ```
+    python -m venv labenv
+    .\labenv\Scripts\Activate.ps1
+    pip install -r requirements.txt
+    ```
+
+    > **Note**: This installs the [azure-search-documents](https://learn.microsoft.com/python/api/overview/azure/search-documents-readme), [azure-ai-contentunderstanding](https://pypi.org/project/azure-ai-contentunderstanding/), and [openai](https://pypi.org/project/openai/) packages and their dependencies.
+
+1. Copy **.env.example** to a new file named **.env** in the same folder, then fill in the values for the tasks you plan to do:
+
+    | Key | Needed by |
+    | --- | --- |
+    | `SEARCH_ENDPOINT` | All tasks |
+    | `SEARCH_QUERY_KEY` | Task 1 |
+    | `SEARCH_INDEX_NAME` | Task 1 (set it to `fabrikam-index`) |
+    | `SEARCH_ADMIN_KEY` | Tasks 2, 3, 4 |
+    | `FOUNDRY_ENDPOINT`, `FOUNDRY_KEY` | Tasks 2, 3, 4 |
+    | `CHAT_DEPLOYMENT_NAME` | Tasks 3, 4 |
+    | `EMBEDDING_DEPLOYMENT_NAME` | Tasks 2, 3, 4 |
+
+1. Save the file (**Ctrl+S**).
+
+    > **Note**: These tasks authenticate with resource keys because that's the quickest path in a lab. For production, Microsoft recommends [role-based access with Microsoft Entra ID](https://learn.microsoft.com/azure/search/search-security-rbac) instead of keys.
+
+## Download the sample documents
+
+Every task uses the same Fabrikam Logistics reference document set.
+
+1. Download [documents.zip](https://github.com/microsoftlearning/mslearn-ai-information-extraction/raw/main/Labfiles/knowledge/documents.zip) from `https://github.com/microsoftlearning/mslearn-ai-information-extraction/raw/main/Labfiles/knowledge/documents.zip` and save it to a local folder.
+1. Extract the downloaded *documents.zip* file and view the PDF files it contains.
+1. **For Task 1**, you'll upload these to blob storage (the task walks you through it).
+1. **For Tasks 2, 3, and 4**, copy the PDF files into the **Labfiles/B-make-extracted-information-searchable/Python/data** folder. Verify they're in place:
+
+    ```
+    dir data
+    ```
+
+## Check you're ready for a task
+
+Each task needs specific values in your `.env`. Before starting a task, run the preflight check
+from the `Python` folder you opened above — it reads your `.env` and tells you what (if anything)
+is missing:
+
+```
+python ../setup/check_env.py --task 1
+```
+
+Swap `1` for the task number you're about to start. That's it — head to any task:
+
+| Task | Page |
+| --- | --- |
+| Task 1 – Build a knowledge mining index | [B1](B1-build-a-knowledge-mining-index.md) |
+| Task 2 – Build a RAG ingestion pipeline | [B2](B2-build-a-rag-ingestion-pipeline.md) |
+| Task 3 – Answer questions with a RAG agent | [B3](B3-answer-questions-with-a-rag-agent.md) |
+| Task 4 – Keep the index fresh with watch mode | [B4](B4-keep-the-index-fresh-with-watch-mode.md) |

--- a/Instructions/Exercises/Consolidated/B1-build-a-knowledge-mining-index.md
+++ b/Instructions/Exercises/Consolidated/B1-build-a-knowledge-mining-index.md
@@ -1,0 +1,238 @@
+---
+lab:
+    title: 'Task 1 – Build a knowledge mining index'
+    description: 'Use the Azure AI Search Import data wizard to crawl a document library, enrich it with AI skills that extract key phrases, people, and locations, then query the index from Search explorer and a Python client app.'
+    level: 200
+    concepts: 'Azure AI Search, indexers, AI enrichment skills, Search explorer, search SDK'
+    islab: true
+    status: 'draft'
+---
+
+# Task 1 — Build a knowledge mining index
+
+*Part of the **Make extracted information searchable** lab. New here? Start with [Getting started](B0-getting-started.md).*
+
+> **Set up (start here):** This task needs an **Azure AI Search** resource, a **storage account**,
+> the sample documents, and the starter code. It does **not** need a Foundry resource. If you
+> haven't already, complete [Getting started](B0-getting-started.md) to create the search and
+> storage resources, download **documents.zip**, clone the code, and set `SEARCH_ENDPOINT`,
+> `SEARCH_QUERY_KEY`, and `SEARCH_INDEX_NAME` in `Python/.env`. Then, from the
+> `Python` folder, verify you're ready:
+
+```
+python ../setup/check_env.py --task 1
+```
+
+---
+
+Fabrikam Logistics has a library of reference documents that everyone knows contains the answers
+and nobody can find anything in. In this task you'll fix that without writing a line of indexing
+code: Azure AI Search will crawl the library, run AI skills over every document to pull out the
+key phrases, people, and places mentioned in it, and build a queryable index.
+
+<style>
+/* "Ask Rani" just-in-time concept blocks */
+details.concept { margin:.6rem 0 1rem; }
+details.concept > summary { display:inline-block; cursor:pointer; list-style:none;
+  font-size:.85em; font-weight:600; color:#0b6a8f; background:#0b6a8f12;
+  border:1px solid #0b6a8f33; border-radius:999px; padding:.2em .7em; }
+details.concept > summary::-webkit-details-marker { display:none; }
+details.concept > summary::before { content:"Ask Rani: "; font-weight:700; }
+details.concept > summary:hover { background:#0b6a8f; color:#fff; border-color:#0b6a8f; }
+details.concept[open] > summary { border-bottom-left-radius:0; border-bottom-right-radius:0; }
+details.concept .concept-body { border:1px solid #0b6a8f33; border-top:none;
+  border-radius:0 8px 8px 8px; padding:.6rem .9rem; background:#0b6a8f08; font-size:.95em; }
+</style>
+
+<details markdown="1" class="concept">
+<summary>What's an indexer, a skill, and an index?</summary>
+<div class="concept-body" markdown="1">
+
+Three pieces, and it's worth keeping them straight:
+
+- A **data source** is where your documents live — here, a blob container.
+- An **indexer** is the crawler. It connects to the data source on a schedule, pulls each
+  document, and pushes the results into an index.
+- A **skillset** is the AI that runs *while* the indexer works. Each **skill** adds something the
+  raw document didn't have: key phrases, recognized people and locations, text read out of
+  images. This is what "AI enrichment" means.
+- An **index** is the searchable result: a set of fields, each marked as searchable, filterable,
+  sortable, or facetable.
+
+The field attributes you set in the wizard aren't cosmetic — a field you don't mark
+**filterable** can't be used in a `$filter`, no matter how much you want it to be later.
+
+[Learn more →](https://learn.microsoft.com/azure/search/search-what-is-azure-search)
+
+</div>
+</details>
+
+## Upload documents to Azure Storage
+
+1. If you haven't already, extract *documents.zip* (downloaded in [Getting started](B0-getting-started.md)) and view the reference documents it contains.
+1. In the Azure portal, navigate to your storage account and select **Storage browser** in the navigation pane.
+1. In the storage browser, select **Blob containers**.
+1. In the toolbar, select **+ Container** and create a new container with the following settings:
+    - **Name**: `documents`
+    - **Anonymous access level**: Private (no anonymous access)
+1. Select the **documents** container, and use the **Upload** toolbar button to upload the .pdf files you extracted from **documents.zip**.
+
+## Create and run an indexer
+
+Now that the documents are in place, create an indexer that uses AI skills to extract information
+from them.
+
+1. In the Azure portal, browse to your Azure AI Search resource. On its **Overview** page, select **Import data**.
+1. On the **Connect to your data** page, in the **Data Source** list, select **Azure Blob Storage**.
+1. Select **keyword search**. Then complete the data store details with the following values:
+    - **Storage account**: *Your storage account*
+    - **Blob container**: Select the **documents** container.
+    - Leave the remaining options as their default values, and then select **Next**.
+
+1. On **Apply AI enrichments**, set the following:
+    - Select **Extract phrases**.
+    - Select **Extract entities**, select the settings icon, ensure only **Persons** and **Locations** are selected, and then select **Save**.
+    - Select **Extract text from images**, select the settings icon, ensure **Generate tags** and **Categorize content** are selected, and then select **Save**.
+    - If it isn't already selected, choose the free Foundry Tools resource option, and then select **Next**.
+
+    > **Note**: The free Foundry Tools enrichment for Azure AI Search can be used to index a maximum of 20 documents. In a production solution, you'd create and attach a dedicated Foundry Tools resource.
+
+1. On **Preview mappings**, set the following configuration:
+    - The fields are already mapped based on the options you selected in the previous step.
+    - Review the following fields and ensure that they're configured as shown in the table. To update a field, select it and then select **Configure field**. Leave all other fields with their default settings.
+
+    | Target index field name | Retrievable | Filterable | Sortable | Facetable | Searchable |
+    | ---------- | ----------- | ---------- | -------- | --------- | ---------- |
+    | metadata_storage_size | &#10004; | &#10004; | &#10004; | | |
+    | metadata_storage_last_modified | &#10004; | &#10004; | &#10004; | | |
+    | title | &#10004; | &#10004; | &#10004; | | &#10004; |
+    | locations | &#10004; | &#10004; | | | &#10004; |
+    | persons | &#10004; | &#10004; | | | &#10004; |
+    | keyPhrases | &#10004; | &#10004; | | | &#10004; |
+
+    - Double-check your selections carefully — the client app later in this task selects and orders by exactly these fields.
+    - Select **Next**.
+
+1. On **Advanced settings**, set the following:
+    - Ensure **Enable semantic ranker** is selected.
+    - If it isn't already selected, set **Schedule** to **Once**.
+    - Select **Next**.
+
+1. On **Review and create**, set **Objects name prefix** to `fabrikam-index` and then select **Create**.
+1. You may close the success notification.
+1. In the navigation pane on the left, under **Search management**, view the **Indexers** page. The **fabrikam-index-indexer** should appear. Wait a few minutes, and select **&orarr; Refresh** until the **Status** indicates **Success**.
+
+## Search the index
+
+Now that you have an index, search it.
+
+1. Return to the **Overview** page for your Azure AI Search resource, and on the toolbar, select **Search explorer**.
+1. In Search explorer, in the **Query string** box, enter `*` (a single asterisk) and then select **Search**.
+
+    This query retrieves all documents in the index in JSON format. Examine the results and note
+    the fields for each document, which include document content, metadata, and the enriched data
+    extracted by the AI skills.
+
+1. In the **View** menu, select **JSON view** and note that the JSON request for the search is shown:
+
+    ```json
+    {
+      "search": "*",
+      "count": true
+    }
+    ```
+
+1. The results include an **@odata.count** field at the top that indicates the number of documents returned by the search.
+
+1. Modify the JSON request to include a **select** parameter:
+
+    ```json
+    {
+      "search": "*",
+      "count": true,
+      "select": "title,locations"
+    }
+    ```
+
+    This time the results include only the file name and any locations mentioned in the document
+    content. The file name is in the **title** field. The **locations** field was generated by an
+    AI skill — it wasn't in the PDF as a field, the skillset inferred it.
+
+1. Try the following query string:
+
+    ```json
+    {
+      "search": "New York",
+      "count": true,
+      "select": "title,keyPhrases"
+    }
+    ```
+
+    This search finds documents that mention "New York" in any searchable field, and returns the
+    file name and key phrases.
+
+1. Try one more query:
+
+    ```json
+    {
+        "search": "New York",
+        "count": true,
+        "select": "title,keyPhrases",
+        "filter": "metadata_storage_size lt 380000"
+    }
+    ```
+
+    This returns documents mentioning "New York" that are smaller than 380,000 bytes. This only
+    works because you marked `metadata_storage_size` as **filterable** in the wizard.
+
+## Query the index from a client application
+
+Search explorer is for you. Your colleagues need an app.
+
+1. In VS Code, open the **.env** file in **Labfiles/B-make-extracted-information-searchable/Python** and confirm:
+    - `SEARCH_ENDPOINT` — the **Url** from your search resource's Overview page
+    - `SEARCH_QUERY_KEY` — the **query** key from **Settings** > **Keys**
+    - `SEARCH_INDEX_NAME` — `fabrikam-index`
+1. Save the file (**Ctrl+S**).
+
+1. Open the `Python` folder and activate the virtual environment from [Getting started](B0-getting-started.md):
+
+    ```
+    .\labenv\Scripts\Activate.ps1
+    ```
+
+1. In VS Code, open the **search-app.py** file.
+
+1. Review the code, which:
+    - Retrieves the configuration settings from the `.env` file.
+    - Creates a `SearchClient` with the endpoint, query key, and index name.
+    - Prompts the user for a search query in a loop (until they type `quit`).
+    - Searches the index using the query, returning the following fields ordered by title:
+        - title
+        - locations
+        - persons
+        - keyPhrases
+    - Parses the search results and displays the fields returned for each document.
+
+    > **Note**: A **query** key is enough here because this app only reads. Tasks 2 and 4 create and write to an index, so they need an **admin** key instead.
+
+1. In the VS Code terminal, run the application:
+
+    ```
+    python search-app.py
+    ```
+
+1. When prompted, enter a query such as `London` and view the results.
+1. Try another query, such as `flights`.
+1. When you're finished testing, enter `quit` to close the app.
+
+> ✅ **Checkpoint**: You've built an AI-enriched search index without writing any indexing code,
+> and queried it both interactively and from an application. That's the Core of this lab. The
+> optional tasks below build a very different kind of index — one you define yourself, with
+> vectors — so you can ask questions in natural language instead of searching for keywords.
+
+When you're finished, enter `deactivate` to exit the virtual environment.
+
+---
+
+**Next (optional):** [Task 2 — Build a RAG ingestion pipeline](B2-build-a-rag-ingestion-pipeline.md)

--- a/Instructions/Exercises/Consolidated/B2-build-a-rag-ingestion-pipeline.md
+++ b/Instructions/Exercises/Consolidated/B2-build-a-rag-ingestion-pipeline.md
@@ -1,0 +1,166 @@
+---
+lab:
+    title: 'Task 2 – Build a RAG ingestion pipeline'
+    description: 'Create a Content Understanding analyzer in code, then run an ingestion pipeline that extracts document content, chunks it, embeds it with Azure OpenAI, and indexes it into Azure AI Search for vector search.'
+    level: 300
+    concepts: 'Content Understanding SDK, chunking, embeddings, vector search, Azure AI Search index definition'
+    islab: true
+    status: 'draft'
+---
+
+# Task 2 — Build a RAG ingestion pipeline
+
+*Part of the **Make extracted information searchable** lab. New here? Start with [Getting started](B0-getting-started.md).*
+
+> **Set up (start here):** This task needs an **Azure AI Search** resource, a **Microsoft Foundry**
+> resource with an embedding model deployed, the sample documents in the `data` folder, and the
+> starter code. It does **not** need anything you built in Task 1 — this task creates its own
+> index from scratch. If you haven't already, complete [Getting started](B0-getting-started.md)
+> and set `SEARCH_ENDPOINT`, `SEARCH_ADMIN_KEY`, `FOUNDRY_ENDPOINT`, `FOUNDRY_KEY`, and
+> `EMBEDDING_DEPLOYMENT_NAME` in `Python/.env`. Then, from the
+> `Python` folder, verify you're ready:
+
+```
+python ../setup/check_env.py --task 2
+```
+
+> **Continuing from a previous task?** If you just finished Task 1, your search resource,
+> virtual environment, and `.env` are already set up. You need to add three things: the
+> `FOUNDRY_*` values, `EMBEDDING_DEPLOYMENT_NAME`, and `SEARCH_ADMIN_KEY` (Task 1's query key
+> can't create an index). You also need the sample PDFs copied into the `Python/data` folder —
+> see [Getting started](B0-getting-started.md). The index you built in Task 1 is untouched;
+> this task creates a separate one.
+
+---
+
+Task 1's index was built *for* you. It's excellent at "find me documents mentioning New York."
+It's useless at "what's our policy on oversized freight?" — because keyword search matches words,
+not meaning, and because the wizard chose the chunking and the fields.
+
+In this task you take control. You'll write the pipeline that extracts, chunks, embeds, and
+indexes Fabrikam Logistics documents, producing an index that supports **vector search**.
+
+<style>
+/* "Ask Rani" just-in-time concept blocks */
+details.concept { margin:.6rem 0 1rem; }
+details.concept > summary { display:inline-block; cursor:pointer; list-style:none;
+  font-size:.85em; font-weight:600; color:#0b6a8f; background:#0b6a8f12;
+  border:1px solid #0b6a8f33; border-radius:999px; padding:.2em .7em; }
+details.concept > summary::-webkit-details-marker { display:none; }
+details.concept > summary::before { content:"Ask Rani: "; font-weight:700; }
+details.concept > summary:hover { background:#0b6a8f; color:#fff; border-color:#0b6a8f; }
+details.concept[open] > summary { border-bottom-left-radius:0; border-bottom-right-radius:0; }
+details.concept .concept-body { border:1px solid #0b6a8f33; border-top:none;
+  border-radius:0 8px 8px 8px; padding:.6rem .9rem; background:#0b6a8f08; font-size:.95em; }
+</style>
+
+<details markdown="1" class="concept">
+<summary>Why chunk documents at all?</summary>
+<div class="concept-body" markdown="1">
+
+Two reasons, and both matter.
+
+**Precision.** If you embed a whole 20-page document as one vector, that vector is an average of
+everything in it — and matches nothing well. Chunks are small enough that each one is *about*
+something.
+
+**Context limits.** At query time you paste retrieved content into the prompt. You can fit three
+useful paragraphs; you can't fit three whole documents.
+
+The trade-off is that chunks that are too small lose the context that made them meaningful. The
+pipeline here splits at **paragraph boundaries** with a 2000-character ceiling, which keeps each
+chunk self-contained. There's no universally right answer — chunking strategy is one of the main
+things you tune in a real RAG system.
+
+</div>
+</details>
+
+Open the `Python` folder and activate the virtual environment from
+[Getting started](B0-getting-started.md) (`.\labenv\Scripts\Activate.ps1`), then continue below.
+
+## Step 1: Create a Content Understanding analyzer
+
+The first stage of the pipeline extracts structured content from each document. You'll create the
+analyzer that does it programmatically.
+
+1. In VS Code, open the **create-analyzer.py** file.
+
+1. Review the code, which:
+    - Loads environment variables from the `.env` file.
+    - Creates a `ContentUnderstandingClient` using the Foundry endpoint and API key.
+    - Defines a document analyzer whose field schema captures a generated `Summary` and a list of `KeyTopics`.
+    - Creates the analyzer by calling `begin_create_analyzer`.
+
+    Notice that the schema asks for `markdown` content *plus* generated fields. The pipeline uses
+    the markdown as the text to chunk and embed, and stores the summary and key topics alongside
+    each chunk as extra searchable metadata.
+
+    > **Note**: The `models` block pins `gpt-5.2` for completion and `text-embedding-3-large` for embedding. If your Foundry resource has different deployments, change them to match — check **Build > Deployments** in the Foundry portal.
+
+1. In the VS Code terminal (with the virtual environment activated), run the script:
+
+    ```
+    python create-analyzer.py
+    ```
+
+1. Wait for the analyzer to be created. The output should confirm that it was created successfully.
+
+## Step 2: Run the ingestion pipeline
+
+Now run the pipeline itself. This single script handles the entire flow — extracting content with
+Content Understanding, generating vector embeddings with Azure OpenAI, and indexing into Azure AI
+Search. It also tracks which files it has already processed, which is what makes Task 4 possible.
+
+1. In VS Code, open the **ingest-pipeline.py** file.
+
+1. Review the code and notice how it:
+    - **Tracks processed files** using a manifest (`processed_files.json`) that records the SHA-256 hash of each file. On each run, the pipeline compares the current hash of every file in the `data/` folder against the manifest, so only new or modified files are processed.
+    - **Ensures the search index exists** by calling `ensure_index()`, which creates or updates the Azure AI Search index with the required schema — text fields, a vector field, and HNSW vector search configuration.
+    - **Extracts content** from each new file by submitting it to the Content Understanding analyzer via `begin_analyze_binary`, which returns markdown content and the extracted fields.
+    - **Chunks the content** by splitting at paragraph boundaries with a 2000-character limit, keeping each chunk self-contained.
+    - **Generates embeddings** for each chunk using the Azure OpenAI embedding model, producing a 3072-dimension vector for semantic search.
+    - **Indexes the chunks** into Azure AI Search using deterministic document IDs (based on the file name and chunk index), so re-ingesting an updated file replaces its old chunks instead of duplicating them.
+    - Supports a `--watch` flag for continuous monitoring (Task 4) and a `--reset` flag to reprocess all files.
+
+    > **Important**: The `EMBEDDING_DIMENSIONS` constant is set to `3072`, which matches `text-embedding-3-large`. If you deployed a different embedding model, change this constant *and* delete the index so it's recreated with the correct vector width — a mismatch here fails at upload time with a confusing error.
+
+1. In the VS Code terminal, run the pipeline:
+
+    ```
+    python ingest-pipeline.py
+    ```
+
+1. Watch the output as the pipeline processes each document. You'll see timestamped log messages showing each file being extracted, chunks being embedded, and results being indexed. For example:
+
+    ```
+    [14:23:01] Verifying search index...
+    [14:23:02] Search index 'fabrikam-rag-index' is ready.
+    [14:23:02] Detected 5 new/updated file(s).
+    [14:23:02]   Processing: route-guide-dubai.pdf
+    [14:23:08]     Embedding chunk 1/3...
+    [14:23:09]     Embedding chunk 2/3...
+    [14:23:09]     Embedding chunk 3/3...
+    [14:23:10]     Indexed 3 chunk(s) from route-guide-dubai.pdf.
+    ...
+    ```
+
+1. After the pipeline finishes, check that it created a **processed_files.json** file in the `Python` folder. This manifest records the hash of each processed file. Run the pipeline again:
+
+    ```
+    python ingest-pipeline.py
+    ```
+
+    This time the output should say `No new files to ingest - all documents are up to date.`
+    Nothing was re-extracted and nothing was re-embedded — which, when embedding calls cost money,
+    is the difference between a pipeline and a script.
+
+1. Optionally, confirm the index exists in the Azure portal: open your Azure AI Search resource, and under **Search management** select **Indexes**. You should see **fabrikam-rag-index** alongside the index from Task 1, with a document count matching the number of chunks the pipeline reported.
+
+> ✅ **Checkpoint**: You've built an index you defined yourself, containing chunked content and
+> embedding vectors. Nothing can query it meaningfully yet — that's Task 3.
+
+When you're finished, enter `deactivate` to exit the virtual environment.
+
+---
+
+**Next (optional):** [Task 3 — Answer questions with a RAG agent](B3-answer-questions-with-a-rag-agent.md)

--- a/Instructions/Exercises/Consolidated/B3-answer-questions-with-a-rag-agent.md
+++ b/Instructions/Exercises/Consolidated/B3-answer-questions-with-a-rag-agent.md
@@ -1,0 +1,145 @@
+---
+lab:
+    title: 'Task 3 – Answer questions with a RAG agent'
+    description: 'Query your vector index with hybrid keyword and vector search, and ground a chat model in the retrieved content so it answers from your documents and cites its sources.'
+    level: 300
+    concepts: 'RAG, hybrid search, vector queries, grounding, prompt construction'
+    islab: true
+    status: 'draft'
+---
+
+# Task 3 — Answer questions with a RAG agent
+
+*Part of the **Make extracted information searchable** lab. New here? Start with [Getting started](B0-getting-started.md).*
+
+> **What you need:** a populated **`fabrikam-rag-index`** in Azure AI Search, a **Microsoft
+> Foundry** resource with both a **chat** and an **embedding** model deployed, and the starter
+> code. This task queries an index — it doesn't create one, so
+> **[Task 2](B2-build-a-rag-ingestion-pipeline.md) must have run successfully first**. If you
+> haven't done Task 2, do it now: it takes about 30 minutes and there's no other way to populate
+> the index. Then set `SEARCH_ENDPOINT`, `SEARCH_ADMIN_KEY`, `FOUNDRY_ENDPOINT`, `FOUNDRY_KEY`,
+> `CHAT_DEPLOYMENT_NAME`, and `EMBEDDING_DEPLOYMENT_NAME` in `Python/.env` and verify from the
+> `Python` folder:
+
+```
+python ../setup/check_env.py --task 3
+```
+
+> **Continuing from a previous task?** If you just finished Task 2, everything is in place except
+> `CHAT_DEPLOYMENT_NAME` — Task 2 only needed the *embedding* model, and this task also needs a
+> chat model to generate answers. Add it to your `.env` and go straight to
+> **Ask questions of your documents** below.
+
+---
+
+You have an index full of chunked content and vectors. On its own, that's a very expensive
+filing cabinet. In this task you'll add the two things that turn it into an assistant: **hybrid
+retrieval** to find the right chunks, and a **grounded prompt** so the model answers from those
+chunks instead of from its own memory.
+
+<style>
+/* "Ask Rani" just-in-time concept blocks */
+details.concept { margin:.6rem 0 1rem; }
+details.concept > summary { display:inline-block; cursor:pointer; list-style:none;
+  font-size:.85em; font-weight:600; color:#0b6a8f; background:#0b6a8f12;
+  border:1px solid #0b6a8f33; border-radius:999px; padding:.2em .7em; }
+details.concept > summary::-webkit-details-marker { display:none; }
+details.concept > summary::before { content:"Ask Rani: "; font-weight:700; }
+details.concept > summary:hover { background:#0b6a8f; color:#fff; border-color:#0b6a8f; }
+details.concept[open] > summary { border-bottom-left-radius:0; border-bottom-right-radius:0; }
+details.concept .concept-body { border:1px solid #0b6a8f33; border-top:none;
+  border-radius:0 8px 8px 8px; padding:.6rem .9rem; background:#0b6a8f08; font-size:.95em; }
+</style>
+
+<details markdown="1" class="concept">
+<summary>Why hybrid search instead of just vectors?</summary>
+<div class="concept-body" markdown="1">
+
+**Keyword search** is exact. Ask for a part number, a person's name, or an unusual acronym and it
+finds it — but it can't match "oversized freight" to a document that says "out-of-gauge cargo."
+
+**Vector search** matches meaning. It handles the paraphrase beautifully — and it can miss the
+literal string you actually needed, because "close in meaning" isn't "identical."
+
+**Hybrid search** runs both and fuses the rankings, so you get exact matches *and* semantic ones.
+For RAG this matters more than almost any other tuning decision, because whatever retrieval
+misses, the model can never mention.
+
+In the code, hybrid is what you get by passing **both** `search_text=` and `vector_queries=` to
+the same `search()` call.
+
+[Learn more →](https://learn.microsoft.com/azure/search/retrieval-augmented-generation-overview)
+
+</div>
+</details>
+
+Open the `Python` folder and activate the virtual environment from
+[Getting started](B0-getting-started.md) (`.\labenv\Scripts\Activate.ps1`), then continue below.
+
+## Review the agent
+
+1. In VS Code, open the **rag-agent.py** file.
+
+1. Review the code, which:
+    - Creates an Azure AI Search client to retrieve documents from `fabrikam-rag-index`.
+    - Creates an Azure OpenAI client pointed at your Foundry resource's `/openai/v1/` endpoint.
+    - Implements `retrieve_context()`, which embeds the user's question with the *same* embedding model the pipeline used, then performs hybrid search (keyword + vector) to find the most relevant content chunks.
+    - Constructs a system prompt that includes the retrieved context and instructs the model to answer only from it, and to cite source document names.
+    - Runs a conversational loop so you can ask multiple questions.
+
+1. Look closely at `retrieve_context()`. Two details are worth noticing:
+
+    ```python
+    results = search_client.search(
+        search_text=question,
+        vector_queries=[vector_query],
+        select=["content", "file_name", "summary"],
+        top=top_k
+    )
+    ```
+
+    Passing `search_text` **and** `vector_queries` together is what makes this hybrid rather than
+    either one alone. And `select` limits what comes back to the three fields the prompt actually
+    uses — retrieving the whole document would waste context budget.
+
+1. Now look at `generate_answer()`. The system message tells the model to use *only* the provided
+   context, to say so when the context is insufficient, and to cite sources. Those three
+   instructions are what stop a RAG app from confidently inventing an answer.
+
+## Ask questions of your documents
+
+1. In the VS Code terminal, run the agent:
+
+    ```
+    python rag-agent.py
+    ```
+
+1. When prompted, enter a question about the content you indexed. For example:
+    - `What destinations are covered in the reference documents?`
+    - `What activities are recommended in Dubai?`
+    - `What can you tell me about travel to London?`
+
+1. Review the agent's responses. They should be grounded in the actual content extracted from the documents, and cite the source document names.
+
+1. Now test the guardrail. Ask something the documents definitely don't cover:
+
+    ```
+    What is Fabrikam Logistics' parental leave policy?
+    ```
+
+    The agent should tell you it can't find relevant information rather than inventing a policy.
+    That behavior comes entirely from the system prompt — remove those instructions and the same
+    model will happily make something up.
+
+1. When you're satisfied, type `quit` to exit the agent.
+
+> ✅ **Checkpoint**: You've built a working RAG solution: hybrid retrieval over your own vector
+> index, feeding a grounded, source-citing chat model. There's one thing still missing — right
+> now it only knows about the documents that were in the folder when you ran the pipeline. Task 4
+> fixes that.
+
+When you're finished, enter `deactivate` to exit the virtual environment.
+
+---
+
+**Next (optional):** [Task 4 — Keep the index fresh with watch mode](B4-keep-the-index-fresh-with-watch-mode.md)

--- a/Instructions/Exercises/Consolidated/B4-keep-the-index-fresh-with-watch-mode.md
+++ b/Instructions/Exercises/Consolidated/B4-keep-the-index-fresh-with-watch-mode.md
@@ -1,0 +1,191 @@
+---
+lab:
+    title: 'Task 4 – Keep the index fresh with watch mode'
+    description: 'Run the ingestion pipeline in watch mode so it detects and ingests new documents automatically, then confirm the RAG agent can answer from content that arrived after you started asking questions.'
+    level: 400
+    concepts: 'continuous ingestion, change detection, manifests, near real-time RAG'
+    islab: true
+    status: 'draft'
+---
+
+# Task 4 — Keep the index fresh with watch mode
+
+*Part of the **Make extracted information searchable** lab. New here? Start with [Getting started](B0-getting-started.md).*
+
+> **What you need:** everything Task 3 needed — a populated **`fabrikam-rag-index`**, a
+> **Microsoft Foundry** resource with **chat** and **embedding** models deployed, and the starter
+> code — plus the ability to run **two terminals side by side**. This task extends the pipeline
+> from [Task 2](B2-build-a-rag-ingestion-pipeline.md) and re-uses the agent from
+> [Task 3](B3-answer-questions-with-a-rag-agent.md), so both should have run successfully first.
+> Verify from the `Python` folder:
+
+```
+python ../setup/check_env.py --task 4
+```
+
+> **Continuing from a previous task?** If you just finished Task 3, you need nothing new — same
+> resources, same `.env`, same virtual environment. Go straight to **Start the pipeline in watch
+> mode** below.
+
+---
+
+Everything you've built so far runs once. Real document libraries don't hold still: an updated
+route guide lands on Monday, and if the index doesn't know about it, your agent confidently
+answers from last month's version.
+
+In this task you'll run the pipeline in **watch mode**, add a document while it's running, and
+watch it become answerable without anyone reprocessing anything.
+
+<style>
+/* "Ask Rani" just-in-time concept blocks */
+details.concept { margin:.6rem 0 1rem; }
+details.concept > summary { display:inline-block; cursor:pointer; list-style:none;
+  font-size:.85em; font-weight:600; color:#0b6a8f; background:#0b6a8f12;
+  border:1px solid #0b6a8f33; border-radius:999px; padding:.2em .7em; }
+details.concept > summary::-webkit-details-marker { display:none; }
+details.concept > summary::before { content:"Ask Rani: "; font-weight:700; }
+details.concept > summary:hover { background:#0b6a8f; color:#fff; border-color:#0b6a8f; }
+details.concept[open] > summary { border-bottom-left-radius:0; border-bottom-right-radius:0; }
+details.concept .concept-body { border:1px solid #0b6a8f33; border-top:none;
+  border-radius:0 8px 8px 8px; padding:.6rem .9rem; background:#0b6a8f08; font-size:.95em; }
+</style>
+
+<details markdown="1" class="concept">
+<summary>Why hash the files instead of checking the timestamp?</summary>
+<div class="concept-body" markdown="1">
+
+The manifest stores a **SHA-256 hash** of every file's contents, not its modified date.
+
+Timestamps lie constantly. Copying a file, syncing a folder, or opening and saving it without
+edits all bump the modified date — and each false positive means re-extracting and re-embedding a
+document you already have, which costs real money at volume. Meanwhile some sync tools *preserve*
+timestamps, so a genuinely changed file can slip through.
+
+A content hash asks the only question that matters: are these bytes different from the bytes I
+processed last time?
+
+It pairs with **deterministic document IDs** (`hash(file_name::chunk_index)`). Because chunk 2 of
+a given file always gets the same ID, re-ingesting an updated document *overwrites* its old
+chunks rather than leaving stale duplicates in the index next to the new ones.
+
+</div>
+</details>
+
+## Start the pipeline in watch mode
+
+1. In VS Code, open a terminal in the `Python` folder (the folder you opened in [Getting started](B0-getting-started.md)) and activate the virtual environment:
+
+    ```
+    .\labenv\Scripts\Activate.ps1
+    ```
+
+1. Start the pipeline in watch mode:
+
+    ```
+    python ingest-pipeline.py --watch
+    ```
+
+    The pipeline begins polling the `data/` folder every 30 seconds. You should see output like:
+
+    ```
+    [14:30:00] Watching 'data/' for new documents (press Ctrl+C to stop)...
+
+    [14:30:01] No new files. Waiting...
+    ```
+
+    **Leave this terminal running.**
+
+## Add a new document
+
+1. In VS Code, open a **second terminal** (select **Terminal** > **New Terminal**) so you can work while the pipeline keeps watching.
+
+1. Switch to the VS Code Explorer pane and right-click the **data** folder under **Labfiles/B-make-extracted-information-searchable/Python**. Select **New File** and name it **tokyo-route-guide.txt**.
+
+1. Add the following content to the new file and save it:
+
+    ```text
+    Tokyo Route Guide
+
+    Tokyo, the capital of Japan, is one of the most dynamic cities in the world,
+    blending centuries-old tradition with cutting-edge technology and innovation.
+    It is also one of the busiest freight and passenger hubs in Asia.
+
+    Key Locations:
+    - Senso-ji Temple: Tokyo's oldest temple, located in Asakusa. The approach
+      through Nakamise-dori shopping street is iconic.
+    - Shibuya Crossing: The world's busiest pedestrian crossing is a symbol of
+      Tokyo's energy and pace.
+    - Meiji Shrine: A serene Shinto shrine set in a lush forest in the heart of
+      the city, dedicated to Emperor Meiji.
+    - Tokyo Skytree: At 634 meters, this broadcasting tower offers panoramic views
+      of the entire metropolitan area.
+    - Tsukiji Outer Market: While the inner wholesale market has moved to Toyosu,
+      the outer market still offers incredible fresh seafood and street food.
+
+    Districts to Know:
+    - Shinjuku: A vibrant district known for its nightlife, shopping, and the
+      Shinjuku Gyoen National Garden.
+    - Akihabara: The hub of anime, manga, and electronics retail.
+    - Harajuku: Known for youth fashion, Takeshita Street, and trendy cafes.
+    - Ginza: Tokyo's upscale shopping and dining district.
+
+    Getting Around:
+    Tokyo has one of the world's most efficient public transportation systems.
+    The Tokyo Metro and JR lines connect every corner of the city. A Suica or
+    Pasmo card makes travel seamless. For longer journeys, the Japan Rail Pass
+    offers unlimited travel on JR lines.
+
+    Best Time to Travel:
+    Spring (March-May) for cherry blossoms and autumn (October-November) for
+    fall foliage are the most popular seasons. Summers can be hot and humid,
+    while winters are mild compared to northern Japan.
+    ```
+
+1. Switch back to the terminal running the pipeline in watch mode. Within 30 seconds, you should see the pipeline detect and process the new file:
+
+    ```
+    [14:31:00] Detected 1 new/updated file(s).
+    [14:31:00]   Processing: tokyo-route-guide.txt
+    [14:31:05]     Embedding chunk 1/1...
+    [14:31:06]     Indexed 1 chunk(s) from tokyo-route-guide.txt.
+    [14:31:06] Ingestion complete - 1 file(s), 1 chunk(s) indexed.
+    ```
+
+    Nobody told it the file existed. It compared hashes, found one it hadn't seen, and ran the
+    full extract-chunk-embed-index flow on just that file.
+
+## Query the newly ingested content
+
+1. Switch to your **second terminal**, activate the virtual environment if you haven't, and run the RAG agent:
+
+    ```
+    .\labenv\Scripts\Activate.ps1
+    python rag-agent.py
+    ```
+
+1. Ask a question about the newly added document:
+    - `What can you tell me about Tokyo?`
+    - `What are the key locations in Tokyo?`
+    - `How do I get around in Tokyo?`
+
+1. The agent should now return answers grounded in the Tokyo route guide — content that didn't exist during your first query session in Task 3. This is the whole point of the pipeline: new knowledge becomes answerable without any manual reprocessing.
+
+1. Optionally, test change detection too. Switch to VS Code, add a line to **tokyo-route-guide.txt**, and save it. Within 30 seconds the watch terminal should re-process the file — and because the chunk IDs are deterministic, it replaces the old chunks rather than adding duplicates.
+
+1. Type `quit` to exit the agent, then switch to the watch-mode terminal and press **Ctrl+C** to stop the pipeline.
+
+> ✅ **Checkpoint**: You've built a continuous ingestion pipeline that keeps a RAG index current
+> as documents arrive, and confirmed end to end that a document added minutes ago is answerable
+> now. That's the difference between a RAG demo and a RAG system.
+
+When you're finished, enter `deactivate` in both terminals to exit the virtual environment.
+
+## More information
+
+- [Tutorial: Build a RAG solution with Content Understanding](https://learn.microsoft.com/azure/ai-services/content-understanding/tutorial/build-rag-solution)
+- [Retrieval-augmented generation in Azure AI Search](https://learn.microsoft.com/azure/search/retrieval-augmented-generation-overview)
+- [Azure Content Understanding Python SDK](https://pypi.org/project/azure-ai-contentunderstanding/)
+
+---
+
+**Next:** You've completed the optional tasks. Head back to the [lab overview](B-make-extracted-information-searchable.md) for a summary and clean-up steps.

--- a/Labfiles/A-extract-information-from-business-content/Python/.env.example
+++ b/Labfiles/A-extract-information-from-business-content/Python/.env.example
@@ -1,0 +1,18 @@
+# Fabrikam Logistics - Lab A: Extract information from business content
+#
+# Copy this file to .env and fill in the values for the tasks you're doing.
+# Task 1 is portal-only and needs nothing here.
+
+# --- Tasks 2 (Content Understanding SDK) --------------------------------
+# Endpoint and key of your Microsoft Foundry resource.
+FOUNDRY_ENDPOINT=your_foundry_endpoint
+FOUNDRY_KEY=your_foundry_key
+# The analyzer that Task 2 creates and then calls.
+ANALYZER_NAME=fabrikam-contact-analyzer
+
+# --- Tasks 3 and 4 (Document Intelligence) ------------------------------
+# Endpoint and key of your Document Intelligence resource.
+DOC_INTELLIGENCE_ENDPOINT=your_document_intelligence_endpoint
+DOC_INTELLIGENCE_KEY=your_document_intelligence_key
+# Task 4 only: the Model ID you gave your trained custom model.
+CUSTOM_MODEL_ID=your_custom_model_id

--- a/Labfiles/A-extract-information-from-business-content/Python/contact-card.json
+++ b/Labfiles/A-extract-information-from-business-content/Python/contact-card.json
@@ -1,0 +1,40 @@
+{
+    "description": "Fabrikam Logistics contact card analyzer",
+    "baseAnalyzerId": "prebuilt-document",
+    "models": {
+        "completion": "gpt-5.2",
+        "embedding": "text-embedding-3-large"
+    },
+    "config": {
+        "returnDetails": true
+    },
+    "fieldSchema": {
+        "fields": {
+            "Company": {
+                "type": "string",
+                "method": "extract",
+                "description": "Company or organization"
+            },
+            "Name": {
+                "type": "string",
+                "method": "extract",
+                "description": "Contact's name"
+            },
+            "Title": {
+                "type": "string",
+                "method": "extract",
+                "description": "Contact's job title"
+            },
+            "Email": {
+                "type": "string",
+                "method": "extract",
+                "description": "Contact's email address"
+            },
+            "Phone": {
+                "type": "string",
+                "method": "extract",
+                "description": "Contact's phone number"
+            }
+        }
+    }
+}

--- a/Labfiles/A-extract-information-from-business-content/Python/create-analyzer.py
+++ b/Labfiles/A-extract-information-from-business-content/Python/create-analyzer.py
@@ -1,0 +1,51 @@
+"""Task 2 - create a Content Understanding analyzer for Fabrikam Logistics contact cards.
+
+Run this once to register the analyzer with your Foundry resource, then use
+read-card.py to analyze scanned contact cards with it.
+"""
+
+from dotenv import load_dotenv
+import os
+import json
+from azure.ai.contentunderstanding import ContentUnderstandingClient
+from azure.core.credentials import AzureKeyCredential
+
+
+def main():
+
+    # Clear the console
+    os.system('cls' if os.name == 'nt' else 'clear')
+
+    try:
+
+        # Get the contact card schema
+        with open("contact-card.json", "r") as file:
+            schema_json = json.load(file)
+
+        card_schema = json.dumps(schema_json)
+
+        # Get config settings
+        load_dotenv()
+        ai_svc_endpoint = os.getenv('FOUNDRY_ENDPOINT')
+        ai_svc_key = os.getenv('FOUNDRY_KEY')
+        analyzer = os.getenv('ANALYZER_NAME')
+
+        # Create the analyzer
+        create_analyzer(card_schema, analyzer, ai_svc_endpoint, ai_svc_key)
+
+        print("\n")
+
+    except Exception as ex:
+        print(ex)
+
+
+def create_analyzer(schema, analyzer, endpoint, key):
+
+    # TODO: Create a Content Understanding analyzer
+    # Create a ContentUnderstandingClient, parse the schema JSON, and call
+    # begin_create_analyzer to register the analyzer with your Foundry resource.
+    pass
+
+
+if __name__ == "__main__":
+    main()

--- a/Labfiles/A-extract-information-from-business-content/Python/document-analysis.py
+++ b/Labfiles/A-extract-information-from-business-content/Python/document-analysis.py
@@ -1,0 +1,46 @@
+"""Task 3 - analyze a supplier invoice with the prebuilt-invoice model.
+
+Fabrikam Logistics receives invoices from dozens of suppliers in different
+layouts. The prebuilt invoice model reads them all without any training.
+"""
+
+from dotenv import load_dotenv
+import os
+
+# TODO: Add references
+# Import AzureKeyCredential, DocumentIntelligenceClient, and AnalyzeDocumentRequest.
+
+
+def main():
+
+    # Clear the console
+    os.system('cls' if os.name == 'nt' else 'clear')
+
+    try:
+        # Get config settings
+        load_dotenv()
+        endpoint = os.getenv('DOC_INTELLIGENCE_ENDPOINT')
+        key = os.getenv('DOC_INTELLIGENCE_KEY')
+
+        # Set analysis settings
+        fileUri = "https://raw.githubusercontent.com/MicrosoftLearning/mslearn-ai-information-extraction/main/Labfiles/03-document-intelligence/prebuilt/sample-invoice/sample-invoice.pdf"
+        fileLocale = "en-US"
+        fileModelId = "prebuilt-invoice"
+
+        print(f"\nConnecting to Azure Document Intelligence at: {endpoint}")
+        print(f"Analyzing invoice at: {fileUri}")
+
+        # TODO: Create the client
+
+        # TODO: Analyze the invoice
+
+        # TODO: Display invoice information to the user
+
+    except Exception as ex:
+        print(ex)
+
+    print("\nAnalysis complete.\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/Labfiles/A-extract-information-from-business-content/Python/read-card.py
+++ b/Labfiles/A-extract-information-from-business-content/Python/read-card.py
@@ -1,0 +1,74 @@
+"""Task 2 - analyze a Fabrikam Logistics contact card with a Content Understanding analyzer.
+
+Usage:
+    python read-card.py                 Analyze the default card (biz-card-1.png)
+    python read-card.py biz-card-2.png  Analyze another sample card
+    python read-card.py C:\\path\\card.png  Analyze a card by full path
+
+Sample cards ship with the repo in Instructions/Exercises/media, so a bare file
+name is resolved from there. No sample images are duplicated into this folder.
+"""
+
+from dotenv import load_dotenv
+import os
+import sys
+import json
+from pathlib import Path
+from azure.ai.contentunderstanding import ContentUnderstandingClient
+from azure.core.credentials import AzureKeyCredential
+
+# Sample cards live with the shared lab media, four levels up from this file:
+# Labfiles/A-extract-information-from-business-content/Python/read-card.py
+MEDIA_DIR = Path(__file__).resolve().parents[3] / "Instructions" / "Exercises" / "media"
+
+
+def resolve_card(name):
+    """Return a path to the card image, looking in the shared media folder."""
+    candidate = Path(name)
+    if candidate.exists():
+        return candidate
+    return MEDIA_DIR / name
+
+
+def main():
+
+    # Clear the console
+    os.system('cls' if os.name == 'nt' else 'clear')
+
+    try:
+
+        # Get the contact card
+        image_file = 'biz-card-1.png'
+        if len(sys.argv) > 1:
+            image_file = sys.argv[1]
+        image_path = resolve_card(image_file)
+
+        if not image_path.exists():
+            print(f"[error] Could not find {image_file}. Looked in {MEDIA_DIR}")
+            return
+
+        # Get config settings
+        load_dotenv()
+        ai_svc_endpoint = os.getenv('FOUNDRY_ENDPOINT')
+        ai_svc_key = os.getenv('FOUNDRY_KEY')
+        analyzer = os.getenv('ANALYZER_NAME')
+
+        # Analyze the contact card
+        analyze_card(str(image_path), analyzer, ai_svc_endpoint, ai_svc_key)
+
+        print("\n")
+
+    except Exception as ex:
+        print(ex)
+
+
+def analyze_card(image_file, analyzer, endpoint, key):
+
+    # TODO: Use Content Understanding to analyze the image
+    # Create a ContentUnderstandingClient, read the image bytes, submit them
+    # with begin_analyze_binary, save the JSON response, and print each field.
+    pass
+
+
+if __name__ == "__main__":
+    main()

--- a/Labfiles/A-extract-information-from-business-content/Python/requirements.txt
+++ b/Labfiles/A-extract-information-from-business-content/Python/requirements.txt
@@ -1,0 +1,3 @@
+python-dotenv==1.2.2
+azure-ai-contentunderstanding==1.1.0
+azure-ai-documentintelligence==1.0.2

--- a/Labfiles/A-extract-information-from-business-content/Python/test-model.py
+++ b/Labfiles/A-extract-information-from-business-content/Python/test-model.py
@@ -1,0 +1,58 @@
+"""Task 4 - test the custom extraction model you trained on Fabrikam Logistics forms.
+
+The model ID comes from your .env, so this file works unchanged once you've
+trained a model in Document Intelligence Studio.
+"""
+
+from azure.core.credentials import AzureKeyCredential
+from azure.ai.documentintelligence import DocumentIntelligenceClient
+from azure.ai.documentintelligence.models import AnalyzeDocumentRequest
+from dotenv import load_dotenv
+import os
+
+
+def main():
+
+    # Clear the console
+    os.system('cls' if os.name == 'nt' else 'clear')
+
+    try:
+        # Get configuration settings
+        load_dotenv()
+        endpoint = os.getenv("DOC_INTELLIGENCE_ENDPOINT")
+        key = os.getenv("DOC_INTELLIGENCE_KEY")
+        model_id = os.getenv("CUSTOM_MODEL_ID")
+
+        formUrl = "https://raw.githubusercontent.com/MicrosoftLearning/mslearn-ai-information-extraction/main/Labfiles/03-document-intelligence/custom/test1.jpg"
+
+        document_analysis_client = DocumentIntelligenceClient(
+            endpoint=endpoint, credential=AzureKeyCredential(key)
+        )
+
+        # Make sure your document's type is included in the list of document
+        # types the custom model can analyze
+        poller = document_analysis_client.begin_analyze_document(
+            model_id,
+            AnalyzeDocumentRequest(url_source=formUrl)
+        )
+        result = poller.result()
+
+        for idx, document in enumerate(result.documents):
+            print("--------Analyzing document #{}--------".format(idx + 1))
+            print("Document has type {}".format(document.doc_type))
+            print("Document has confidence {}".format(document.confidence))
+            print("Document was analyzed by model with ID {}".format(result.model_id))
+            for name, field in document.fields.items():
+                field_value = field.get("valueString") or field.get("content", "N/A")
+                print("Found field '{}' with value '{}' and with confidence {}".format(
+                    name, field_value, field.get("confidence")))
+
+        print("-----------------------------------")
+    except Exception as ex:
+        print(ex)
+
+    print("\nAnalysis complete.\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/Labfiles/A-extract-information-from-business-content/Solution/Python/.env.example
+++ b/Labfiles/A-extract-information-from-business-content/Solution/Python/.env.example
@@ -1,0 +1,18 @@
+# Fabrikam Logistics - Lab A: Extract information from business content
+#
+# Copy this file to .env and fill in the values for the tasks you're doing.
+# Task 1 is portal-only and needs nothing here.
+
+# --- Tasks 2 (Content Understanding SDK) --------------------------------
+# Endpoint and key of your Microsoft Foundry resource.
+FOUNDRY_ENDPOINT=your_foundry_endpoint
+FOUNDRY_KEY=your_foundry_key
+# The analyzer that Task 2 creates and then calls.
+ANALYZER_NAME=fabrikam-contact-analyzer
+
+# --- Tasks 3 and 4 (Document Intelligence) ------------------------------
+# Endpoint and key of your Document Intelligence resource.
+DOC_INTELLIGENCE_ENDPOINT=your_document_intelligence_endpoint
+DOC_INTELLIGENCE_KEY=your_document_intelligence_key
+# Task 4 only: the Model ID you gave your trained custom model.
+CUSTOM_MODEL_ID=your_custom_model_id

--- a/Labfiles/A-extract-information-from-business-content/Solution/Python/contact-card.json
+++ b/Labfiles/A-extract-information-from-business-content/Solution/Python/contact-card.json
@@ -1,0 +1,40 @@
+{
+    "description": "Fabrikam Logistics contact card analyzer",
+    "baseAnalyzerId": "prebuilt-document",
+    "models": {
+        "completion": "gpt-5.2",
+        "embedding": "text-embedding-3-large"
+    },
+    "config": {
+        "returnDetails": true
+    },
+    "fieldSchema": {
+        "fields": {
+            "Company": {
+                "type": "string",
+                "method": "extract",
+                "description": "Company or organization"
+            },
+            "Name": {
+                "type": "string",
+                "method": "extract",
+                "description": "Contact's name"
+            },
+            "Title": {
+                "type": "string",
+                "method": "extract",
+                "description": "Contact's job title"
+            },
+            "Email": {
+                "type": "string",
+                "method": "extract",
+                "description": "Contact's email address"
+            },
+            "Phone": {
+                "type": "string",
+                "method": "extract",
+                "description": "Contact's phone number"
+            }
+        }
+    }
+}

--- a/Labfiles/A-extract-information-from-business-content/Solution/Python/create-analyzer.py
+++ b/Labfiles/A-extract-information-from-business-content/Solution/Python/create-analyzer.py
@@ -1,0 +1,69 @@
+"""Task 2 - create a Content Understanding analyzer for Fabrikam Logistics contact cards.
+
+Completed reference implementation.
+"""
+
+from dotenv import load_dotenv
+import os
+import json
+from azure.ai.contentunderstanding import ContentUnderstandingClient
+from azure.core.credentials import AzureKeyCredential
+
+
+def main():
+
+    # Clear the console
+    os.system('cls' if os.name == 'nt' else 'clear')
+
+    try:
+
+        # Get the contact card schema
+        with open("contact-card.json", "r") as file:
+            schema_json = json.load(file)
+
+        card_schema = json.dumps(schema_json)
+
+        # Get config settings
+        load_dotenv()
+        ai_svc_endpoint = os.getenv('FOUNDRY_ENDPOINT')
+        ai_svc_key = os.getenv('FOUNDRY_KEY')
+        analyzer = os.getenv('ANALYZER_NAME')
+
+        # Create the analyzer
+        create_analyzer(card_schema, analyzer, ai_svc_endpoint, ai_svc_key)
+
+        print("\n")
+
+    except Exception as ex:
+        print(ex)
+
+
+def create_analyzer(schema, analyzer, endpoint, key):
+
+    # Create a Content Understanding analyzer
+    print(f"Creating {analyzer}")
+
+    # Create the Content Understanding client
+    client = ContentUnderstandingClient(
+        endpoint=endpoint,
+        credential=AzureKeyCredential(key)
+    )
+
+    # Parse the schema JSON into a ContentAnalyzer object
+    analyzer_definition = json.loads(schema)
+
+    # Create the analyzer using the SDK (long-running operation)
+    poller = client.begin_create_analyzer(
+        analyzer_id=analyzer,
+        resource=analyzer_definition,
+        allow_replace=True
+    )
+
+    # Wait for the operation to complete
+    result = poller.result()
+    print(f"Analyzer '{analyzer}' created successfully.")
+    print(f"Status: {result['status'] if isinstance(result, dict) else 'Succeeded'}")
+
+
+if __name__ == "__main__":
+    main()

--- a/Labfiles/A-extract-information-from-business-content/Solution/Python/document-analysis.py
+++ b/Labfiles/A-extract-information-from-business-content/Solution/Python/document-analysis.py
@@ -1,0 +1,71 @@
+"""Task 3 - analyze a supplier invoice with the prebuilt-invoice model.
+
+Completed reference implementation.
+"""
+
+from dotenv import load_dotenv
+import os
+
+# Add references
+from azure.core.credentials import AzureKeyCredential
+from azure.ai.documentintelligence import DocumentIntelligenceClient
+from azure.ai.documentintelligence.models import AnalyzeDocumentRequest
+
+
+def main():
+
+    # Clear the console
+    os.system('cls' if os.name == 'nt' else 'clear')
+
+    try:
+        # Get config settings
+        load_dotenv()
+        endpoint = os.getenv('DOC_INTELLIGENCE_ENDPOINT')
+        key = os.getenv('DOC_INTELLIGENCE_KEY')
+
+        # Set analysis settings
+        fileUri = "https://raw.githubusercontent.com/MicrosoftLearning/mslearn-ai-information-extraction/main/Labfiles/03-document-intelligence/prebuilt/sample-invoice/sample-invoice.pdf"
+        fileLocale = "en-US"
+        fileModelId = "prebuilt-invoice"
+
+        print(f"\nConnecting to Azure Document Intelligence at: {endpoint}")
+        print(f"Analyzing invoice at: {fileUri}")
+
+        # Create the client
+        document_analysis_client = DocumentIntelligenceClient(
+            endpoint=endpoint, credential=AzureKeyCredential(key)
+        )
+
+        # Analyze the invoice
+        poller = document_analysis_client.begin_analyze_document(
+            fileModelId,
+            AnalyzeDocumentRequest(url_source=fileUri),
+            locale=fileLocale
+        )
+
+        # Display invoice information to the user
+        result = poller.result()
+
+        for document in result.documents:
+
+            vendor_name = document.fields.get("VendorName")
+            if vendor_name:
+                print(f"\nVendor Name: {vendor_name.get('valueString')}, with confidence {vendor_name.get('confidence')}.")
+
+            customer_name = document.fields.get("CustomerName")
+            if customer_name:
+                print(f"Customer Name: {customer_name.get('valueString')}, with confidence {customer_name.get('confidence')}.")
+
+            invoice_total = document.fields.get("InvoiceTotal")
+            if invoice_total:
+                amount = invoice_total.get("valueCurrency", {})
+                print(f"Invoice Total: {amount.get('currencySymbol', '$')}{amount.get('amount')}, with confidence {invoice_total.get('confidence')}.")
+
+    except Exception as ex:
+        print(ex)
+
+    print("\nAnalysis complete.\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/Labfiles/A-extract-information-from-business-content/Solution/Python/read-card.py
+++ b/Labfiles/A-extract-information-from-business-content/Solution/Python/read-card.py
@@ -1,0 +1,104 @@
+"""Task 2 - analyze a Fabrikam Logistics contact card with a Content Understanding analyzer.
+
+Completed reference implementation.
+
+Usage:
+    python read-card.py                 Analyze the default card (biz-card-1.png)
+    python read-card.py biz-card-2.png  Analyze another sample card
+"""
+
+from dotenv import load_dotenv
+import os
+import sys
+import json
+from pathlib import Path
+from azure.ai.contentunderstanding import ContentUnderstandingClient
+from azure.core.credentials import AzureKeyCredential
+
+# Sample cards live with the shared lab media, five levels up from this file:
+# Labfiles/A-extract-information-from-business-content/Solution/Python/read-card.py
+MEDIA_DIR = Path(__file__).resolve().parents[4] / "Instructions" / "Exercises" / "media"
+
+
+def resolve_card(name):
+    """Return a path to the card image, looking in the shared media folder."""
+    candidate = Path(name)
+    if candidate.exists():
+        return candidate
+    return MEDIA_DIR / name
+
+
+def main():
+
+    # Clear the console
+    os.system('cls' if os.name == 'nt' else 'clear')
+
+    try:
+
+        # Get the contact card
+        image_file = 'biz-card-1.png'
+        if len(sys.argv) > 1:
+            image_file = sys.argv[1]
+        image_path = resolve_card(image_file)
+
+        if not image_path.exists():
+            print(f"[error] Could not find {image_file}. Looked in {MEDIA_DIR}")
+            return
+
+        # Get config settings
+        load_dotenv()
+        ai_svc_endpoint = os.getenv('FOUNDRY_ENDPOINT')
+        ai_svc_key = os.getenv('FOUNDRY_KEY')
+        analyzer = os.getenv('ANALYZER_NAME')
+
+        # Analyze the contact card
+        analyze_card(str(image_path), analyzer, ai_svc_endpoint, ai_svc_key)
+
+        print("\n")
+
+    except Exception as ex:
+        print(ex)
+
+
+def analyze_card(image_file, analyzer, endpoint, key):
+
+    # Use Content Understanding to analyze the image
+    print(f"Analyzing {image_file}")
+
+    # Create the Content Understanding client
+    client = ContentUnderstandingClient(
+        endpoint=endpoint,
+        credential=AzureKeyCredential(key)
+    )
+
+    # Read the image data
+    with open(image_file, "rb") as file:
+        image_data = file.read()
+
+    # Submit the image for analysis
+    print("Submitting request...")
+    poller = client.begin_analyze_binary(
+        analyzer_id=analyzer,
+        binary_input=image_data
+    )
+
+    # Wait for the analysis to complete
+    result = poller.result()
+    print("Analysis succeeded:\n")
+
+    # Save JSON results to a file
+    output_file = "results.json"
+    with open(output_file, "w") as json_file:
+        json.dump(dict(result), json_file, indent=4, default=str)
+        print(f"Response saved in {output_file}\n")
+
+    # Iterate through the contents and extract fields
+    for content in result.contents:
+        if hasattr(content, 'fields') and content.fields:
+            for field_name, field_data in content.fields.items():
+                value = field_data.value if hasattr(field_data, 'value') else None
+                print(f"{field_name}: {value}")
+
+
+if __name__ == "__main__":
+    main()

--- a/Labfiles/A-extract-information-from-business-content/Solution/Python/requirements.txt
+++ b/Labfiles/A-extract-information-from-business-content/Solution/Python/requirements.txt
@@ -1,0 +1,3 @@
+python-dotenv==1.2.2
+azure-ai-contentunderstanding==1.1.0
+azure-ai-documentintelligence==1.0.2

--- a/Labfiles/A-extract-information-from-business-content/Solution/Python/test-model.py
+++ b/Labfiles/A-extract-information-from-business-content/Solution/Python/test-model.py
@@ -1,0 +1,58 @@
+"""Task 4 - test the custom extraction model you trained on Fabrikam Logistics forms.
+
+The model ID comes from your .env, so this file works unchanged once you've
+trained a model in Document Intelligence Studio.
+"""
+
+from azure.core.credentials import AzureKeyCredential
+from azure.ai.documentintelligence import DocumentIntelligenceClient
+from azure.ai.documentintelligence.models import AnalyzeDocumentRequest
+from dotenv import load_dotenv
+import os
+
+
+def main():
+
+    # Clear the console
+    os.system('cls' if os.name == 'nt' else 'clear')
+
+    try:
+        # Get configuration settings
+        load_dotenv()
+        endpoint = os.getenv("DOC_INTELLIGENCE_ENDPOINT")
+        key = os.getenv("DOC_INTELLIGENCE_KEY")
+        model_id = os.getenv("CUSTOM_MODEL_ID")
+
+        formUrl = "https://raw.githubusercontent.com/MicrosoftLearning/mslearn-ai-information-extraction/main/Labfiles/03-document-intelligence/custom/test1.jpg"
+
+        document_analysis_client = DocumentIntelligenceClient(
+            endpoint=endpoint, credential=AzureKeyCredential(key)
+        )
+
+        # Make sure your document's type is included in the list of document
+        # types the custom model can analyze
+        poller = document_analysis_client.begin_analyze_document(
+            model_id,
+            AnalyzeDocumentRequest(url_source=formUrl)
+        )
+        result = poller.result()
+
+        for idx, document in enumerate(result.documents):
+            print("--------Analyzing document #{}--------".format(idx + 1))
+            print("Document has type {}".format(document.doc_type))
+            print("Document has confidence {}".format(document.confidence))
+            print("Document was analyzed by model with ID {}".format(result.model_id))
+            for name, field in document.fields.items():
+                field_value = field.get("valueString") or field.get("content", "N/A")
+                print("Found field '{}' with value '{}' and with confidence {}".format(
+                    name, field_value, field.get("confidence")))
+
+        print("-----------------------------------")
+    except Exception as ex:
+        print(ex)
+
+    print("\nAnalysis complete.\n")
+
+
+if __name__ == "__main__":
+    main()

--- a/Labfiles/A-extract-information-from-business-content/Solution/README.md
+++ b/Labfiles/A-extract-information-from-business-content/Solution/README.md
@@ -20,7 +20,7 @@ Labfiles/A-extract-information-from-business-content/
     README.md                this file
     Python/                  COMPLETE reference implementation
   setup/
-    check_env.py             preflight check: python setup/check_env.py --task N
+    check_env.py             preflight check: python ../setup/check_env.py --task N
     upload-training-forms.sh Task 4 - uploads labeled training forms to storage
 ```
 
@@ -28,7 +28,8 @@ Task 1 is completed entirely in the browser, so it has no code.
 
 ## How to run each task
 
-All commands run from `Labfiles/A-extract-information-from-business-content/Python`
+All commands run from the **starter** folder,
+`Labfiles/A-extract-information-from-business-content/Python`,
 with the virtual environment activated:
 
 ```
@@ -44,7 +45,9 @@ pip install -r requirements.txt
 | Task 3 | `python document-analysis.py` | `DOC_INTELLIGENCE_ENDPOINT`, `DOC_INTELLIGENCE_KEY` |
 | Task 4 | `bash ../setup/upload-training-forms.sh`, train in Studio, then `python test-model.py` | `DOC_INTELLIGENCE_ENDPOINT`, `DOC_INTELLIGENCE_KEY`, `CUSTOM_MODEL_ID` |
 
-Before starting a task, check you have what it needs (run from the `Python` folder):
+Before starting a task, check you have what it needs. Run this from the
+**starter** `Python/` folder — *not* from `Solution/Python/`, where `../setup/`
+would resolve to a `Solution/setup/` folder that doesn't exist:
 
 ```
 python ../setup/check_env.py --task 2

--- a/Labfiles/A-extract-information-from-business-content/Solution/README.md
+++ b/Labfiles/A-extract-information-from-business-content/Solution/README.md
@@ -1,0 +1,70 @@
+# Lab A solution - Extract information from business content
+
+Completed reference implementations for the **Extract information from business content**
+lab. Use these if you get stuck, or to compare against your own code. The starter
+files you edit during the lab are in `../Python/`.
+
+## File tree
+
+```
+Labfiles/A-extract-information-from-business-content/
+  Python/                    STARTER - the files you edit during the lab
+    .env.example             copy to .env and fill in
+    requirements.txt
+    contact-card.json        analyzer schema used by Task 2
+    create-analyzer.py       Task 2 - has a TODO
+    read-card.py             Task 2 - has a TODO
+    document-analysis.py     Task 3 - has TODOs
+    test-model.py            Task 4 - complete, no TODOs
+  Solution/
+    README.md                this file
+    Python/                  COMPLETE reference implementation
+  setup/
+    check_env.py             preflight check: python setup/check_env.py --task N
+    upload-training-forms.sh Task 4 - uploads labeled training forms to storage
+```
+
+Task 1 is completed entirely in the browser, so it has no code.
+
+## How to run each task
+
+All commands run from `Labfiles/A-extract-information-from-business-content/Python`
+with the virtual environment activated:
+
+```
+python -m venv labenv
+.\labenv\Scripts\Activate.ps1
+pip install -r requirements.txt
+```
+
+| Task | Command | Needs in `.env` |
+| --- | --- | --- |
+| Task 1 | *(portal only)* | nothing |
+| Task 2 | `python create-analyzer.py` then `python read-card.py biz-card-1.png` | `FOUNDRY_ENDPOINT`, `FOUNDRY_KEY`, `ANALYZER_NAME` |
+| Task 3 | `python document-analysis.py` | `DOC_INTELLIGENCE_ENDPOINT`, `DOC_INTELLIGENCE_KEY` |
+| Task 4 | `bash ../setup/upload-training-forms.sh`, train in Studio, then `python test-model.py` | `DOC_INTELLIGENCE_ENDPOINT`, `DOC_INTELLIGENCE_KEY`, `CUSTOM_MODEL_ID` |
+
+Before starting a task, check you have what it needs (run from the `Python` folder):
+
+```
+python ../setup/check_env.py --task 2
+```
+
+## Notes
+
+- **Sample images aren't duplicated.** `read-card.py` resolves a bare file name
+  such as `biz-card-1.png` from `Instructions/Exercises/media/`, so the sample
+  contact cards that ship with the repo are used in place. You can also pass a
+  full path to any image of your own.
+- **Two services, one lab.** Tasks 1 and 2 use Azure Content Understanding
+  (LLM-powered analyzers you define with a schema). Tasks 3 and 4 use Azure
+  Document Intelligence (deterministic extraction, prebuilt and custom models).
+  Both are part of Foundry Tools, and the lab uses one `.env` for both.
+- **API keys.** These tasks authenticate with resource keys because that's the
+  quickest path in a lab. For production, Microsoft recommends Microsoft Entra
+  ID with `DefaultAzureCredential` instead - see
+  [Authenticate requests to Foundry Tools](https://learn.microsoft.com/azure/ai-services/authentication).
+- **Models.** The Task 2 analyzer schema in `contact-card.json` pins
+  `gpt-5.2` for completion and `text-embedding-3-large` for embedding. If your
+  Foundry resource doesn't have those deployments, change them to models you do
+  have deployed.

--- a/Labfiles/A-extract-information-from-business-content/setup/check_env.py
+++ b/Labfiles/A-extract-information-from-business-content/setup/check_env.py
@@ -25,10 +25,14 @@ import os
 from pathlib import Path
 
 # Escape sequences a quoted value decodes. Double quotes decode the full
-# set; single quotes decode only the delimiter and the backslash itself -
-# everything else stays literal. Measured against python-dotenv, not
+# C-style set; single quotes decode only the delimiter and the backslash
+# itself - everything else stays literal. Measured against python-dotenv, not
 # assumed: 'raw \n stays' keeps the backslash, but 'a\'b' yields a'b.
-_ESCAPES_DOUBLE = {"n": "\n", "r": "\r", "t": "\t", "\\": "\\", '"': '"', "'": "'"}
+_ESCAPES_DOUBLE = {
+    "n": "\n", "r": "\r", "t": "\t",
+    "a": "\a", "b": "\b", "f": "\f", "v": "\v",
+    "\\": "\\", '"': '"', "'": "'",
+}
 _ESCAPES_SINGLE = {"\\": "\\", "'": "'"}
 
 # Kept for callers/tests that reference the original name.

--- a/Labfiles/A-extract-information-from-business-content/setup/check_env.py
+++ b/Labfiles/A-extract-information-from-business-content/setup/check_env.py
@@ -43,6 +43,8 @@ except ImportError:
                     if line.startswith("export "):
                         line = line[len("export "):].lstrip()
                     if "=" not in line:
+                        # python-dotenv records a bare key with no '=' as None.
+                        values[line] = None
                         continue
                     key, _, value = line.partition("=")
                     key = key.strip()

--- a/Labfiles/A-extract-information-from-business-content/setup/check_env.py
+++ b/Labfiles/A-extract-information-from-business-content/setup/check_env.py
@@ -24,7 +24,38 @@ import argparse
 import os
 from pathlib import Path
 
-from dotenv import dotenv_values
+try:
+    from dotenv import dotenv_values
+except ImportError:
+    # python-dotenv is installed into the lab's virtual environment, but this
+    # preflight check is meant to run BEFORE 'pip install -r requirements.txt'
+    # (and Task 1 is portal-only, so that install may never happen). Fall back
+    # to a small standard-library parser so the check always works.
+    def dotenv_values(path):
+        """Minimal .env reader used when python-dotenv isn't installed."""
+        values = {}
+        try:
+            with open(path, "r", encoding="utf-8-sig") as handle:
+                for raw_line in handle:
+                    line = raw_line.strip()
+                    if not line or line.startswith("#"):
+                        continue
+                    if line.startswith("export "):
+                        line = line[len("export "):].lstrip()
+                    if "=" not in line:
+                        continue
+                    key, _, value = line.partition("=")
+                    key = key.strip()
+                    value = value.strip()
+                    if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+                        value = value[1:-1]
+                    else:
+                        value = value.split(" #", 1)[0].strip()
+                    if key:
+                        values[key] = value
+        except OSError:
+            return {}
+        return values
 
 # Which .env keys each task needs to run on its own.
 TASK_REQUIREMENTS = {

--- a/Labfiles/A-extract-information-from-business-content/setup/check_env.py
+++ b/Labfiles/A-extract-information-from-business-content/setup/check_env.py
@@ -24,40 +24,58 @@ import argparse
 import os
 from pathlib import Path
 
+def _parse_env_file(path):
+    """Minimal .env reader used when python-dotenv isn't installed.
+
+    Defined at module level (rather than inside the ImportError branch below)
+    so it can be imported and tested directly even when python-dotenv is
+    available. Its output matches dotenv.dotenv_values for the .env syntax
+    these labs use.
+    """
+    values = {}
+    try:
+        with open(path, "r", encoding="utf-8-sig") as handle:
+            for raw_line in handle:
+                line = raw_line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                # Strip 'export ' before splitting, so the key is the real
+                # name and not 'export KEY'.
+                if line.startswith("export "):
+                    line = line[len("export "):].lstrip()
+                if "=" not in line:
+                    # python-dotenv records a bare key with no '=' as None.
+                    values[line] = None
+                    continue
+                key, _, value = line.partition("=")
+                key = key.strip()
+                value = value.strip()
+                if value[:1] in ("'", '"'):
+                    # Quoted: take what's inside the quotes, so a '#' inside
+                    # is kept and a trailing comment outside is dropped.
+                    quote = value[0]
+                    end = value.find(quote, 1)
+                    if end == -1:
+                        # Unterminated quote; python-dotenv drops the key.
+                        continue
+                    value = value[1:end]
+                else:
+                    value = value.split(" #", 1)[0].strip()
+                if key:
+                    values[key] = value
+    except OSError:
+        return {}
+    return values
+
+
 try:
-    from dotenv import dotenv_values
-except ImportError:
     # python-dotenv is installed into the lab's virtual environment, but this
     # preflight check is meant to run BEFORE 'pip install -r requirements.txt'
-    # (and Task 1 is portal-only, so that install may never happen). Fall back
-    # to a small standard-library parser so the check always works.
-    def dotenv_values(path):
-        """Minimal .env reader used when python-dotenv isn't installed."""
-        values = {}
-        try:
-            with open(path, "r", encoding="utf-8-sig") as handle:
-                for raw_line in handle:
-                    line = raw_line.strip()
-                    if not line or line.startswith("#"):
-                        continue
-                    if line.startswith("export "):
-                        line = line[len("export "):].lstrip()
-                    if "=" not in line:
-                        # python-dotenv records a bare key with no '=' as None.
-                        values[line] = None
-                        continue
-                    key, _, value = line.partition("=")
-                    key = key.strip()
-                    value = value.strip()
-                    if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
-                        value = value[1:-1]
-                    else:
-                        value = value.split(" #", 1)[0].strip()
-                    if key:
-                        values[key] = value
-        except OSError:
-            return {}
-        return values
+    # (and Task 1 is portal-only, so that install may never happen), so fall
+    # back to the stdlib parser above when it isn't importable.
+    from dotenv import dotenv_values
+except ImportError:
+    dotenv_values = _parse_env_file
 
 # Which .env keys each task needs to run on its own.
 TASK_REQUIREMENTS = {

--- a/Labfiles/A-extract-information-from-business-content/setup/check_env.py
+++ b/Labfiles/A-extract-information-from-business-content/setup/check_env.py
@@ -24,7 +24,15 @@ import argparse
 import os
 from pathlib import Path
 
-_ESCAPES = {"n": "\n", "r": "\r", "t": "\t", "\\": "\\", '"': '"', "'": "'"}
+# Escape sequences a quoted value decodes. Double quotes decode the full
+# set; single quotes decode only the delimiter and the backslash itself -
+# everything else stays literal. Measured against python-dotenv, not
+# assumed: 'raw \n stays' keeps the backslash, but 'a\'b' yields a'b.
+_ESCAPES_DOUBLE = {"n": "\n", "r": "\r", "t": "\t", "\\": "\\", '"': '"', "'": "'"}
+_ESCAPES_SINGLE = {"\\": "\\", "'": "'"}
+
+# Kept for callers/tests that reference the original name.
+_ESCAPES = _ESCAPES_DOUBLE
 
 
 def _has_utf8_bom(path):
@@ -185,17 +193,21 @@ def _parse_env_file(path):
 
         if value[:1] in ("'", '"'):
             quote = value[0]
+            escapes = _ESCAPES_DOUBLE if quote == '"' else _ESCAPES_SINGLE
             chars = []
             index = 1
             closed = False
             while index < len(value):
                 char = value[index]
-                # Only double quotes process backslash escapes, so a \" does
-                # not end the value and \n becomes a real newline. Decoding
-                # happens in this single pass so an escaped backslash isn't
-                # re-processed.
-                if quote == '"' and char == "\\" and index + 1 < len(value):
-                    chars.append(_ESCAPES.get(value[index + 1], "\\" + value[index + 1]))
+                # Both quote styles honour a backslash escape, but they decode
+                # different sets: a \" does not end a double-quoted value and
+                # \n becomes a newline, while a single-quoted value decodes
+                # only \' and \\ and leaves every other escape literal.
+                # Decoding happens in this single pass so an escaped backslash
+                # isn't re-processed.
+                if char == "\\" and index + 1 < len(value):
+                    nxt = value[index + 1]
+                    chars.append(escapes.get(nxt, "\\" + nxt))
                     index += 2
                     continue
                 if char == quote:

--- a/Labfiles/A-extract-information-from-business-content/setup/check_env.py
+++ b/Labfiles/A-extract-information-from-business-content/setup/check_env.py
@@ -27,68 +27,157 @@ from pathlib import Path
 _ESCAPES = {"n": "\n", "r": "\r", "t": "\t", "\\": "\\", '"': '"', "'": "'"}
 
 
+def _has_utf8_bom(path):
+    """True if the file starts with a UTF-8 BOM.
+
+    Checked on the raw bytes, so the result is the same whether python-dotenv
+    or the fallback parser below did the reading.
+    """
+    try:
+        with open(path, "rb") as handle:
+            return handle.read(3) == b"\xef\xbb\xbf"
+    except OSError:
+        return False
+
+
+BOM_HINT = (
+    "Your .env was saved as 'UTF-8 with BOM' (Notepad does this by default). "
+    "The BOM becomes part of the first setting's name, so the app reads that "
+    "setting as empty even though the file looks correct. Re-save as plain "
+    "UTF-8: in VS Code, click the encoding in the status bar, choose 'Save "
+    "with Encoding', then 'UTF-8' (not 'UTF-8 with BOM')."
+)
+
+
+def _find_unterminated_quote(path):
+    """Return the 1-based line number of the first unterminated quoted value.
+
+    Read from the raw file, so the answer is the same whether python-dotenv or
+    the fallback parser did the reading. An unterminated quote is why a set of
+    otherwise-correct settings can vanish: python-dotenv keeps scanning for the
+    closing quote and swallows the lines it crosses, so the app never sees them.
+    """
+    try:
+        with open(path, "r", encoding="utf-8-sig") as handle:
+            for number, raw_line in enumerate(handle, start=1):
+                line = raw_line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                if line.startswith("export "):
+                    line = line[len("export "):].lstrip()
+                if "=" not in line:
+                    continue
+                _, _, value = line.partition("=")
+                value = value.strip()
+                if value[:1] not in ("'", '"'):
+                    continue
+                quote = value[0]
+                index = 1
+                closed = False
+                while index < len(value):
+                    char = value[index]
+                    if quote == '"' and char == "\\" and index + 1 < len(value):
+                        index += 2
+                        continue
+                    if char == quote:
+                        closed = True
+                        break
+                    index += 1
+                if not closed:
+                    return number
+    except OSError:
+        return None
+    return None
+
+
+def _unterminated_hint(line_number):
+    return (
+        f"Line {line_number} of your .env opens a quote that is never closed. "
+        "python-dotenv keeps looking for the closing quote on the lines that "
+        "follow, so that setting - and potentially every setting after it - is "
+        f"read as one long value and never reaches the app. Close the quote on "
+        f"line {line_number} (or remove both quotes; these settings don't need "
+        "them)."
+    )
+
+
 def _parse_env_file(path):
     """Minimal .env reader used when python-dotenv isn't installed.
 
     Defined at module level (rather than inside the ImportError branch below)
     so it can be imported and tested directly even when python-dotenv is
-    available. Its output matches dotenv.dotenv_values for every well-formed
-    .env construct these labs use.
-
-    One intentional deviation: python-dotenv treats an unterminated quote as
-    the start of a multi-line value, so it swallows the following lines and
-    the keys defined on them silently disappear. This parser instead drops
-    only the malformed line and keeps every later key, so a typo in one value
-    can't make unrelated settings look MISSING.
+    available. Its output matches dotenv.dotenv_values, including the awkward
+    cases, because this check has to agree with what the app will actually
+    see at runtime - the app reads the same file with python-dotenv.
     """
-    values = {}
     try:
         with open(path, "r", encoding="utf-8-sig") as handle:
-            for raw_line in handle:
-                line = raw_line.strip()
-                if not line or line.startswith("#"):
-                    continue
-                # Strip 'export ' before splitting, so the key is the real
-                # name and not 'export KEY'.
-                if line.startswith("export "):
-                    line = line[len("export "):].lstrip()
-                if "=" not in line:
-                    # python-dotenv records a bare key with no '=' as None.
-                    values[line] = None
-                    continue
-                key, _, value = line.partition("=")
-                key = key.strip()
-                value = value.strip()
-                if value[:1] in ("'", '"'):
-                    quote = value[0]
-                    chars = []
-                    index = 1
-                    closed = False
-                    while index < len(value):
-                        char = value[index]
-                        # Only double quotes process backslash escapes, so a
-                        # \" doesn't end the value and \n becomes a newline.
-                        if quote == '"' and char == "\\" and index + 1 < len(value):
-                            nxt = value[index + 1]
-                            chars.append(_ESCAPES.get(nxt, "\\" + nxt))
-                            index += 2
-                            continue
-                        if char == quote:
-                            closed = True
-                            break
-                        chars.append(char)
-                        index += 1
-                    if not closed:
-                        # Unterminated quote; python-dotenv drops the key.
-                        continue
-                    # Anything after the closing quote is a trailing comment.
-                    value = "".join(chars)
-                else:
-                    value = value.split(" #", 1)[0].strip()
-                if key:
-                    values[key] = value
+            lines = handle.readlines()
     except OSError:
         return {}
+
+    values = {}
+    position = 0
+    while position < len(lines):
+        line = lines[position].strip()
+        position += 1
+
+        if not line or line.startswith("#"):
+            continue
+        # Strip 'export ' before splitting, so the key is the real name and
+        # not 'export KEY'.
+        if line.startswith("export "):
+            line = line[len("export "):].lstrip()
+        if "=" not in line:
+            # python-dotenv records a bare key with no '=' as None.
+            values[line] = None
+            continue
+
+        key, _, value = line.partition("=")
+        key = key.strip()
+        value = value.strip()
+
+        if value[:1] in ("'", '"'):
+            quote = value[0]
+            chars = []
+            index = 1
+            closed = False
+            while index < len(value):
+                char = value[index]
+                # Only double quotes process backslash escapes, so a \" does
+                # not end the value and \n becomes a real newline. Decoding
+                # happens in this single pass so an escaped backslash isn't
+                # re-processed.
+                if quote == '"' and char == "\\" and index + 1 < len(value):
+                    chars.append(_ESCAPES.get(value[index + 1], "\\" + value[index + 1]))
+                    index += 2
+                    continue
+                if char == quote:
+                    closed = True
+                    break
+                chars.append(char)
+                index += 1
+
+            if not closed:
+                # python-dotenv treats this as the start of a multi-line
+                # value and scans ahead for the matching quote. If it finds
+                # one, every line up to it is swallowed and the keys on those
+                # lines never reach the app; if it doesn't, only this line is
+                # dropped. Either way the malformed entry itself is discarded.
+                lookahead = position
+                while lookahead < len(lines) and quote not in lines[lookahead]:
+                    lookahead += 1
+                if lookahead < len(lines):
+                    position = lookahead + 1
+                continue
+
+            value = "".join(chars)
+        else:
+            value = value.split(" #", 1)[0].strip()
+
+        if key:
+            values[key] = value
+
     return values
 
 
@@ -183,7 +272,13 @@ def load_values(env_path):
     """Merge real environment variables over .env file values (env wins)."""
     values = {}
     if env_path.exists():
-        values.update({k: v for k, v in dotenv_values(env_path).items() if v is not None})
+        for key, value in dotenv_values(env_path).items():
+            if value is None:
+                continue
+            # A UTF-8 BOM ends up glued to the first key's name. Strip it here
+            # so the per-key report is still readable; the BOM itself is
+            # reported separately as a problem, never silently accepted.
+            values[key.lstrip("\ufeff")] = value
     for key in ALL_KEYS:
         if os.environ.get(key):
             values[key] = os.environ[key]
@@ -212,6 +307,8 @@ def main():
     env_path = find_env_file()
     values = load_values(env_path)
     required = TASK_REQUIREMENTS[args.task]
+    has_bom = env_path.exists() and _has_utf8_bom(env_path)
+    bad_quote_line = _find_unterminated_quote(env_path) if env_path.exists() else None
 
     print(f"Checking readiness for Task {args.task}")
     print(f"Reading: {env_path}{'' if env_path.exists() else '  (not found yet)'}")
@@ -229,13 +326,25 @@ def main():
         mark = "OK " if is_set(values, key) else "MISSING"
         print(f"  [{mark}] {key}")
 
-    if not missing:
+    # These two break the app even when the keys look right, so neither is
+    # ever treated as "ready" - the app would fail after this said OK. They're
+    # also usually the root cause of the MISSING keys listed above.
+    if has_bom:
+        print("  [PROBLEM] .env starts with a UTF-8 BOM")
+    if bad_quote_line:
+        print(f"  [PROBLEM] .env line {bad_quote_line}: unterminated quote")
+
+    if not missing and not has_bom and not bad_quote_line:
         print()
         print(f"You're ready to start Task {args.task}.")
         return 0
 
     print()
-    print("Set the following before starting this task:")
+    print("Fix the following before starting this task:")
+    if has_bom:
+        print(f"\n  .env encoding\n    {BOM_HINT}")
+    if bad_quote_line:
+        print(f"\n  .env line {bad_quote_line}\n    {_unterminated_hint(bad_quote_line)}")
     for key in missing:
         print(f"\n  {key}\n    {FIX_HINTS.get(key, 'Add this key to your .env file.')}")
     return 1

--- a/Labfiles/A-extract-information-from-business-content/setup/check_env.py
+++ b/Labfiles/A-extract-information-from-business-content/setup/check_env.py
@@ -167,6 +167,17 @@ def _parse_env_file(path):
     available. Its output matches dotenv.dotenv_values, including the awkward
     cases, because this check has to agree with what the app will actually
     see at runtime - the app reads the same file with python-dotenv.
+
+    INTENTIONAL DIVERGENCE - do not "fix" this to match dotenv:
+        This reads with utf-8-sig, so a UTF-8 BOM is stripped and the first
+        key parses under its real name. python-dotenv does NOT do that - it
+        returns the first key as "\\ufeffNAME". The difference is deliberate:
+        it lets the per-key report stay readable, and the BOM is caught
+        separately by _has_utf8_bom(), which forces the check to fail with an
+        explanation. Removing the strip to gain byte-parity with dotenv would
+        make the per-key output confusing without adding any safety, because
+        the safety lives in the detector, not in the parser. A parser-level
+        differential test cannot see this - assert it at check level instead.
     """
     try:
         with open(path, "r", encoding="utf-8-sig") as handle:
@@ -349,10 +360,49 @@ def load_values(env_path):
     return values
 
 
+def _placeholder_values():
+    """PLACEHOLDERS plus any placeholder-looking value in the shipped
+    .env.example, so the list can't silently rot when the example is edited.
+
+    Only values that *look* like placeholders are absorbed. .env.example also
+    ships real pre-filled values - an analyzer id, an index name, model names -
+    that a learner is meant to keep. Absorbing those would report a correctly
+    configured .env as MISSING, so the behavioural assertion to test is
+    "an unedited copy of .env.example is not ready", never "every value in
+    .env.example is a placeholder".
+    """
+    values = set(PLACEHOLDERS)
+    example = Path(__file__).resolve().parent.parent / "Python" / ".env.example"
+    try:
+        with open(example, "r", encoding="utf-8-sig") as handle:
+            for line in handle:
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                value = line.partition("=")[2].strip()
+                lowered = value.lower()
+                if lowered.startswith("your_") or lowered.startswith("your-"):
+                    values.add(value)
+    except OSError:
+        pass
+    return values
+
+
+_PLACEHOLDER_CACHE = None
+
+
+def _all_placeholders():
+    """Cached placeholder set (PLACEHOLDERS unioned with the example file)."""
+    global _PLACEHOLDER_CACHE
+    if _PLACEHOLDER_CACHE is None:
+        _PLACEHOLDER_CACHE = _placeholder_values()
+    return _PLACEHOLDER_CACHE
+
+
 def is_set(values, key):
     """A key counts as set if it's present and not a leftover placeholder."""
     value = (values.get(key) or "").strip()
-    return bool(value) and value not in PLACEHOLDERS
+    return bool(value) and value not in _all_placeholders()
 
 
 def main():

--- a/Labfiles/A-extract-information-from-business-content/setup/check_env.py
+++ b/Labfiles/A-extract-information-from-business-content/setup/check_env.py
@@ -3,9 +3,10 @@ Preflight check for the Fabrikam Logistics "Extract information from business
 content" lab (Lab A).
 
 Each task in this lab can be completed on its own. Before you start a task,
-run this script to confirm your .env file has everything that task needs:
+run this script from the starter `Python` folder (the one you edit during the
+lab - NOT `Solution/Python`) to confirm your .env has everything that task needs:
 
-    python setup/check_env.py --task 2
+    python ../setup/check_env.py --task 2
 
 It never changes anything - it only reads your .env and tells you what (if
 anything) is missing, so you can fix it before running the task.

--- a/Labfiles/A-extract-information-from-business-content/setup/check_env.py
+++ b/Labfiles/A-extract-information-from-business-content/setup/check_env.py
@@ -24,13 +24,22 @@ import argparse
 import os
 from pathlib import Path
 
+_ESCAPES = {"n": "\n", "r": "\r", "t": "\t", "\\": "\\", '"': '"', "'": "'"}
+
+
 def _parse_env_file(path):
     """Minimal .env reader used when python-dotenv isn't installed.
 
     Defined at module level (rather than inside the ImportError branch below)
     so it can be imported and tested directly even when python-dotenv is
-    available. Its output matches dotenv.dotenv_values for the .env syntax
-    these labs use.
+    available. Its output matches dotenv.dotenv_values for every well-formed
+    .env construct these labs use.
+
+    One intentional deviation: python-dotenv treats an unterminated quote as
+    the start of a multi-line value, so it swallows the following lines and
+    the keys defined on them silently disappear. This parser instead drops
+    only the malformed line and keeps every later key, so a typo in one value
+    can't make unrelated settings look MISSING.
     """
     values = {}
     try:
@@ -51,14 +60,29 @@ def _parse_env_file(path):
                 key = key.strip()
                 value = value.strip()
                 if value[:1] in ("'", '"'):
-                    # Quoted: take what's inside the quotes, so a '#' inside
-                    # is kept and a trailing comment outside is dropped.
                     quote = value[0]
-                    end = value.find(quote, 1)
-                    if end == -1:
+                    chars = []
+                    index = 1
+                    closed = False
+                    while index < len(value):
+                        char = value[index]
+                        # Only double quotes process backslash escapes, so a
+                        # \" doesn't end the value and \n becomes a newline.
+                        if quote == '"' and char == "\\" and index + 1 < len(value):
+                            nxt = value[index + 1]
+                            chars.append(_ESCAPES.get(nxt, "\\" + nxt))
+                            index += 2
+                            continue
+                        if char == quote:
+                            closed = True
+                            break
+                        chars.append(char)
+                        index += 1
+                    if not closed:
                         # Unterminated quote; python-dotenv drops the key.
                         continue
-                    value = value[1:end]
+                    # Anything after the closing quote is a trailing comment.
+                    value = "".join(chars)
                 else:
                     value = value.split(" #", 1)[0].strip()
                 if key:

--- a/Labfiles/A-extract-information-from-business-content/setup/check_env.py
+++ b/Labfiles/A-extract-information-from-business-content/setup/check_env.py
@@ -1,0 +1,169 @@
+"""
+Preflight check for the Fabrikam Logistics "Extract information from business
+content" lab (Lab A).
+
+Each task in this lab can be completed on its own. Before you start a task,
+run this script to confirm your .env file has everything that task needs:
+
+    python setup/check_env.py --task 2
+
+It never changes anything - it only reads your .env and tells you what (if
+anything) is missing, so you can fix it before running the task.
+
+Tasks and what they need:
+
+    Task 1  (portal) nothing - Task 1 is done entirely in the browser
+    Task 2  (code)   FOUNDRY_ENDPOINT, FOUNDRY_KEY, ANALYZER_NAME
+    Task 3  (code)   DOC_INTELLIGENCE_ENDPOINT, DOC_INTELLIGENCE_KEY
+    Task 4  (code)   DOC_INTELLIGENCE_ENDPOINT, DOC_INTELLIGENCE_KEY,
+                     CUSTOM_MODEL_ID
+"""
+
+import argparse
+import os
+from pathlib import Path
+
+from dotenv import dotenv_values
+
+# Which .env keys each task needs to run on its own.
+TASK_REQUIREMENTS = {
+    1: [],
+    2: ["FOUNDRY_ENDPOINT", "FOUNDRY_KEY", "ANALYZER_NAME"],
+    3: ["DOC_INTELLIGENCE_ENDPOINT", "DOC_INTELLIGENCE_KEY"],
+    4: ["DOC_INTELLIGENCE_ENDPOINT", "DOC_INTELLIGENCE_KEY", "CUSTOM_MODEL_ID"],
+}
+
+# Every key this lab might read, used when merging real environment variables.
+ALL_KEYS = [
+    "FOUNDRY_ENDPOINT",
+    "FOUNDRY_KEY",
+    "ANALYZER_NAME",
+    "DOC_INTELLIGENCE_ENDPOINT",
+    "DOC_INTELLIGENCE_KEY",
+    "CUSTOM_MODEL_ID",
+]
+
+# Placeholder text shipped in .env.example - present but not yet filled in.
+PLACEHOLDERS = {
+    "",
+    "your_foundry_endpoint",
+    "your_foundry_key",
+    "your_document_intelligence_endpoint",
+    "your_document_intelligence_key",
+    "your_custom_model_id",
+    "YOUR_ENDPOINT",
+    "YOUR_KEY",
+    "your_endpoint",
+    "your_key",
+    "your_model_id",
+}
+
+# How to fix each key, shown only when it's missing.
+FIX_HINTS = {
+    "FOUNDRY_ENDPOINT": (
+        "Copy the Endpoint from the Overview page of your Microsoft Foundry "
+        "resource in the Azure portal (or from Resource Management > Keys and "
+        "Endpoint), then set FOUNDRY_ENDPOINT in .env."
+    ),
+    "FOUNDRY_KEY": (
+        "Copy one of the keys from Resource Management > Keys and Endpoint on "
+        "your Microsoft Foundry resource, then set FOUNDRY_KEY in .env."
+    ),
+    "ANALYZER_NAME": (
+        "Set ANALYZER_NAME to the analyzer id you want to create, for example "
+        "fabrikam-contact-analyzer (this ships pre-filled in .env.example)."
+    ),
+    "DOC_INTELLIGENCE_ENDPOINT": (
+        "Copy the Endpoint from Resource Management > Keys and Endpoint on your "
+        "Document Intelligence resource, then set DOC_INTELLIGENCE_ENDPOINT."
+    ),
+    "DOC_INTELLIGENCE_KEY": (
+        "Copy one of the keys from Resource Management > Keys and Endpoint on "
+        "your Document Intelligence resource, then set DOC_INTELLIGENCE_KEY."
+    ),
+    "CUSTOM_MODEL_ID": (
+        "Task 4 needs the Model ID you entered when you trained your custom "
+        "model in Document Intelligence Studio. Set CUSTOM_MODEL_ID in .env."
+    ),
+}
+
+
+def find_env_file():
+    """Return the .env next to the lab's Python folder, wherever this is run from."""
+    here = Path(__file__).resolve().parent
+    candidates = [
+        Path.cwd() / ".env",
+        here.parent / "Python" / ".env",
+        here.parent / ".env",
+    ]
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    # Default to the Python-folder location even if it doesn't exist yet.
+    return here.parent / "Python" / ".env"
+
+
+def load_values(env_path):
+    """Merge real environment variables over .env file values (env wins)."""
+    values = {}
+    if env_path.exists():
+        values.update({k: v for k, v in dotenv_values(env_path).items() if v is not None})
+    for key in ALL_KEYS:
+        if os.environ.get(key):
+            values[key] = os.environ[key]
+    return values
+
+
+def is_set(values, key):
+    """A key counts as set if it's present and not a leftover placeholder."""
+    value = (values.get(key) or "").strip()
+    return bool(value) and value not in PLACEHOLDERS
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Check that your .env has what a given lab task needs."
+    )
+    parser.add_argument(
+        "--task",
+        type=int,
+        choices=sorted(TASK_REQUIREMENTS),
+        required=True,
+        help="Which task you're about to start (1-4).",
+    )
+    args = parser.parse_args()
+
+    env_path = find_env_file()
+    values = load_values(env_path)
+    required = TASK_REQUIREMENTS[args.task]
+
+    print(f"Checking readiness for Task {args.task}")
+    print(f"Reading: {env_path}{'' if env_path.exists() else '  (not found yet)'}")
+    print()
+
+    if not required:
+        print("  Task 1 runs entirely in the browser - no .env values needed.")
+        print()
+        print("You're ready to start Task 1.")
+        return 0
+
+    missing = [key for key in required if not is_set(values, key)]
+
+    for key in required:
+        mark = "OK " if is_set(values, key) else "MISSING"
+        print(f"  [{mark}] {key}")
+
+    if not missing:
+        print()
+        print(f"You're ready to start Task {args.task}.")
+        return 0
+
+    print()
+    print("Set the following before starting this task:")
+    for key in missing:
+        print(f"\n  {key}\n    {FIX_HINTS.get(key, 'Add this key to your .env file.')}")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Labfiles/A-extract-information-from-business-content/setup/check_env.py
+++ b/Labfiles/A-extract-information-from-business-content/setup/check_env.py
@@ -90,14 +90,37 @@ def _find_unterminated_quote(path):
     return None
 
 
-def _unterminated_hint(line_number):
+def _keys_written_in_file(path):
+    """Return the key names that physically appear as assignments in the file.
+
+    Used to tell a key that was never written from one that IS written but got
+    eaten by a malformation, so the check can report the difference honestly.
+    """
+    written = set()
+    try:
+        with open(path, "r", encoding="utf-8-sig") as handle:
+            for raw_line in handle:
+                line = raw_line.strip().lstrip("\ufeff")
+                if not line or line.startswith("#"):
+                    continue
+                if line.startswith("export "):
+                    line = line[len("export "):].lstrip()
+                if "=" not in line:
+                    continue
+                written.add(line.partition("=")[0].strip())
+    except OSError:
+        return written
+    return written
+
+
+def _unterminated_hint(line_number, eaten):
+    keys = ", ".join(eaten)
     return (
         f"Line {line_number} of your .env opens a quote that is never closed. "
         "python-dotenv keeps looking for the closing quote on the lines that "
-        "follow, so that setting - and potentially every setting after it - is "
-        f"read as one long value and never reaches the app. Close the quote on "
-        f"line {line_number} (or remove both quotes; these settings don't need "
-        "them)."
+        f"follow, so {keys} is in your file but never reaches the app. Close "
+        f"the quote on line {line_number} (or remove both quotes; these "
+        "settings don't need them)."
     )
 
 
@@ -321,20 +344,29 @@ def main():
         return 0
 
     missing = [key for key in required if not is_set(values, key)]
+    # A key that's written in the file but absent from the parsed result was
+    # eaten by the malformation - that's the difference between "you never set
+    # this" and "you set this and it isn't reaching the app".
+    written = _keys_written_in_file(env_path) if env_path.exists() else set()
+    eaten = [key for key in required if key in written and key not in values]
 
     for key in required:
         mark = "OK " if is_set(values, key) else "MISSING"
         print(f"  [{mark}] {key}")
 
-    # These two break the app even when the keys look right, so neither is
-    # ever treated as "ready" - the app would fail after this said OK. They're
-    # also usually the root cause of the MISSING keys listed above.
+    # A BOM always corrupts the first setting, so it's always fatal. An
+    # unterminated quote is only fatal when it actually ate something this
+    # task needs - a stray quote below the keys in use changes nothing, and
+    # failing the check for it would be its own false alarm.
     if has_bom:
         print("  [PROBLEM] .env starts with a UTF-8 BOM")
-    if bad_quote_line:
+    if bad_quote_line and eaten:
         print(f"  [PROBLEM] .env line {bad_quote_line}: unterminated quote")
+    elif bad_quote_line:
+        print(f"  [NOTE] .env line {bad_quote_line}: unterminated quote "
+              f"(nothing this task needs is affected)")
 
-    if not missing and not has_bom and not bad_quote_line:
+    if not missing and not has_bom:
         print()
         print(f"You're ready to start Task {args.task}.")
         return 0
@@ -343,9 +375,12 @@ def main():
     print("Fix the following before starting this task:")
     if has_bom:
         print(f"\n  .env encoding\n    {BOM_HINT}")
-    if bad_quote_line:
-        print(f"\n  .env line {bad_quote_line}\n    {_unterminated_hint(bad_quote_line)}")
+    if bad_quote_line and eaten:
+        print(f"\n  .env line {bad_quote_line}\n"
+              f"    {_unterminated_hint(bad_quote_line, eaten)}")
     for key in missing:
+        if key in eaten:
+            continue  # already explained by the unterminated-quote note above
         print(f"\n  {key}\n    {FIX_HINTS.get(key, 'Add this key to your .env file.')}")
     return 1
 

--- a/Labfiles/A-extract-information-from-business-content/setup/check_env.py
+++ b/Labfiles/A-extract-information-from-business-content/setup/check_env.py
@@ -124,6 +124,29 @@ def _unterminated_hint(line_number, eaten):
     )
 
 
+def _find_closing_line(lines, start, quote, honor_escapes):
+    """Index of the first line at/after `start` containing an unescaped quote.
+
+    Returns None if there isn't one. Note that while recovering from an
+    unterminated value python-dotenv honours backslash escapes for BOTH quote
+    characters, even though single-quoted values are otherwise literal.
+    """
+    index = start
+    while index < len(lines):
+        line = lines[index]
+        position = 0
+        while position < len(line):
+            char = line[position]
+            if honor_escapes and char == "\\" and position + 1 < len(line):
+                position += 2
+                continue
+            if char == quote:
+                return index
+            position += 1
+        index += 1
+    return None
+
+
 def _parse_env_file(path):
     """Minimal .env reader used when python-dotenv isn't installed.
 
@@ -183,14 +206,16 @@ def _parse_env_file(path):
 
             if not closed:
                 # python-dotenv treats this as the start of a multi-line
-                # value and scans ahead for the matching quote. If it finds
-                # one, every line up to it is swallowed and the keys on those
-                # lines never reach the app; if it doesn't, only this line is
-                # dropped. Either way the malformed entry itself is discarded.
-                lookahead = position
-                while lookahead < len(lines) and quote not in lines[lookahead]:
-                    lookahead += 1
-                if lookahead < len(lines):
+                # value and scans ahead for the matching quote. It is
+                # escape-aware while doing so, but if no escaped-quote-aware
+                # close exists anywhere it retries treating every quote
+                # character literally - so an escaped quote can still end the
+                # recovery when it's the only candidate. Neither pass alone
+                # reproduces both behaviours.
+                lookahead = _find_closing_line(lines, position, quote, True)
+                if lookahead is None:
+                    lookahead = _find_closing_line(lines, position, quote, False)
+                if lookahead is not None:
                     position = lookahead + 1
                 continue
 

--- a/Labfiles/A-extract-information-from-business-content/setup/upload-training-forms.sh
+++ b/Labfiles/A-extract-information-from-business-content/setup/upload-training-forms.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Task 4 - upload the Fabrikam Logistics sample forms used to train a custom
+# Document Intelligence extraction model.
+#
+# This creates a storage account, uploads the labeled training forms, and
+# prints a Shared Access Signature (SAS) URI you paste into Document
+# Intelligence Studio.
+#
+# The training forms are the ones that already ship with this repo, so nothing
+# is duplicated. Override SAMPLE_FORMS_DIR if you keep them somewhere else.
+
+# Set variable values
+subscription_id="YOUR_SUBSCRIPTION_ID"
+resource_group="YOUR_RESOURCE_GROUP"
+location="YOUR_LOCATION_NAME"
+expiry_date="2028-01-01T00:00:00Z"
+
+# Labeled training forms shipped with the repo (relative to this script).
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SAMPLE_FORMS_DIR="${SAMPLE_FORMS_DIR:-$script_dir/../../03-document-intelligence/custom/sample-forms}"
+
+if [ ! -d "$SAMPLE_FORMS_DIR" ]; then
+    echo "Could not find the sample forms at: $SAMPLE_FORMS_DIR"
+    echo "Set SAMPLE_FORMS_DIR to the folder that holds the labeled training forms."
+    exit 1
+fi
+
+# Get random numbers to create unique resource names
+unique_id=$((1 + RANDOM % 99999))
+
+# Create a storage account in your Azure resource group
+echo "Creating storage..."
+az storage account create --name "fabrikamform$unique_id" --subscription "$subscription_id" --resource-group "$resource_group" --location "$location" --sku Standard_LRS --encryption-services blob --default-action Allow --allow-blob-public-access true --only-show-errors --output none
+
+echo "Uploading files from $SAMPLE_FORMS_DIR ..."
+# Get storage key to create a container in the storage account
+key_json=$(az storage account keys list --subscription "$subscription_id" --resource-group "$resource_group" --account-name "fabrikamform$unique_id" --query "[?keyName=='key1'].{keyName:keyName, permissions:permissions, value:value}")
+key_string=$(echo "$key_json" | jq -r '.[0].value')
+AZURE_STORAGE_KEY=${key_string}
+
+# Create a container
+az storage container create --account-name "fabrikamform$unique_id" --name sampleforms --public-access blob --auth-mode key --account-key "$AZURE_STORAGE_KEY" --output none
+
+# Upload each training form to the sampleforms container as a blob
+az storage blob upload-batch -d sampleforms -s "$SAMPLE_FORMS_DIR" --account-name "fabrikamform$unique_id" --auth-mode key --account-key "$AZURE_STORAGE_KEY" --output none
+
+# Set a variable value for future use
+STORAGE_ACCT_NAME="fabrikamform$unique_id"
+
+# Get a Shared Access Signature (a signed URI that points to one or more storage resources) for the blobs in sampleforms
+SAS_TOKEN=$(az storage container generate-sas --account-name "fabrikamform$unique_id" --name sampleforms --expiry "$expiry_date" --permissions rwl --auth-mode key --account-key "$AZURE_STORAGE_KEY")
+URI="https://$STORAGE_ACCT_NAME.blob.core.windows.net/sampleforms?$SAS_TOKEN"
+
+# Print the generated SAS URI, which authorizes access to the training data
+echo "-------------------------------------"
+echo "Storage account: $STORAGE_ACCT_NAME"
+echo "SAS URI: $URI"

--- a/Labfiles/B-make-extracted-information-searchable/Python/.env.example
+++ b/Labfiles/B-make-extracted-information-searchable/Python/.env.example
@@ -1,0 +1,23 @@
+# Fabrikam Logistics - Lab B: Make extracted information searchable
+#
+# Copy this file to .env and fill in the values for the tasks you're doing.
+
+# --- Task 1 (knowledge mining search client) ----------------------------
+# Azure AI Search endpoint, e.g. https://your-search.search.windows.net
+SEARCH_ENDPOINT=your_search_endpoint
+# Query key (read-only) - enough for Task 1.
+SEARCH_QUERY_KEY=your_query_key
+# The index the portal wizard built for you.
+SEARCH_INDEX_NAME=fabrikam-index
+
+# --- Tasks 2, 3 and 4 (RAG pipeline) ------------------------------------
+# Admin key - Tasks 2 and 4 create and write to an index, so a query key
+# isn't enough.
+SEARCH_ADMIN_KEY=your_search_admin_key
+
+# Microsoft Foundry resource: used for both Content Understanding and the
+# Azure OpenAI chat and embedding models.
+FOUNDRY_ENDPOINT=your_foundry_endpoint
+FOUNDRY_KEY=your_foundry_key
+CHAT_DEPLOYMENT_NAME=gpt-5.2
+EMBEDDING_DEPLOYMENT_NAME=text-embedding-3-large

--- a/Labfiles/B-make-extracted-information-searchable/Python/create-analyzer.py
+++ b/Labfiles/B-make-extracted-information-searchable/Python/create-analyzer.py
@@ -1,0 +1,81 @@
+"""Task 2 - create the Content Understanding analyzer used by the ingestion pipeline.
+
+Run this once. It registers an analyzer that returns markdown content plus a
+generated summary and key topics for every document Fabrikam Logistics ingests.
+"""
+
+from dotenv import load_dotenv
+import os
+from azure.ai.contentunderstanding import ContentUnderstandingClient
+from azure.core.credentials import AzureKeyCredential
+
+ANALYZER_ID = "fabrikam_document_analyzer"
+
+
+def main():
+    """Create a Content Understanding analyzer for extracting content from documents."""
+
+    # Clear the console
+    os.system('cls' if os.name == 'nt' else 'clear')
+
+    try:
+        # Get config settings
+        load_dotenv()
+        endpoint = os.getenv('FOUNDRY_ENDPOINT')
+        key = os.getenv('FOUNDRY_KEY')
+
+        print(f"Creating analyzer '{ANALYZER_ID}'...")
+
+        # Create the Content Understanding client
+        client = ContentUnderstandingClient(
+            endpoint=endpoint,
+            credential=AzureKeyCredential(key)
+        )
+
+        # Define the analyzer schema for document extraction
+        analyzer_definition = {
+            "description": "Analyzer for extracting structured content from Fabrikam Logistics documents",
+            "baseAnalyzerId": "prebuilt-document",
+            "models": {
+                "completion": "gpt-5.2",
+                "embedding": "text-embedding-3-large"
+            },
+            "config": {
+                "returnDetails": True
+            },
+            "fieldSchema": {
+                "fields": {
+                    "Summary": {
+                        "type": "string",
+                        "method": "generate",
+                        "description": "A brief summary of the document content"
+                    },
+                    "KeyTopics": {
+                        "type": "array",
+                        "method": "generate",
+                        "description": "Key topics or themes covered in the document",
+                        "items": {
+                            "type": "string"
+                        }
+                    }
+                }
+            }
+        }
+
+        # Create the analyzer (long-running operation)
+        poller = client.begin_create_analyzer(
+            analyzer_id=ANALYZER_ID,
+            resource=analyzer_definition,
+            allow_replace=True
+        )
+
+        # Wait for the operation to complete
+        poller.result()
+        print(f"Analyzer '{ANALYZER_ID}' created successfully.")
+
+    except Exception as ex:
+        print(f"Error: {ex}")
+
+
+if __name__ == "__main__":
+    main()

--- a/Labfiles/B-make-extracted-information-searchable/Python/data/README.md
+++ b/Labfiles/B-make-extracted-information-searchable/Python/data/README.md
@@ -1,0 +1,7 @@
+# Sample data
+
+Tasks 2, 3, and 4 ingest the documents in this folder.
+
+Download the document set linked from the exercise instructions and extract the
+PDF files here before running `ingest-pipeline.py`. In Task 4 you add a new file
+to this folder and watch the pipeline pick it up automatically.

--- a/Labfiles/B-make-extracted-information-searchable/Python/ingest-pipeline.py
+++ b/Labfiles/B-make-extracted-information-searchable/Python/ingest-pipeline.py
@@ -1,0 +1,351 @@
+"""Automated RAG ingestion pipeline for Fabrikam Logistics.
+
+Monitors a data folder for new or updated documents, extracts content using
+Azure Content Understanding, generates embeddings with Azure OpenAI, and
+indexes the results into Azure AI Search.
+
+Usage:
+    python ingest-pipeline.py            Process new files once and exit
+    python ingest-pipeline.py --watch    Continuously watch for new files
+    python ingest-pipeline.py --reset    Clear tracking data and reprocess all files
+"""
+
+import argparse
+import glob
+import hashlib
+import json
+import os
+import time
+from datetime import datetime
+
+from azure.ai.contentunderstanding import ContentUnderstandingClient
+from azure.core.credentials import AzureKeyCredential
+from azure.search.documents import SearchClient
+from azure.search.documents.indexes import SearchIndexClient
+from azure.search.documents.indexes.models import (
+    HnswAlgorithmConfiguration,
+    SearchField,
+    SearchFieldDataType,
+    SearchableField,
+    SearchIndex,
+    SimpleField,
+    VectorSearch,
+    VectorSearchProfile,
+)
+from dotenv import load_dotenv
+from openai import OpenAI
+
+# ----- Configuration -------------------------------------------------------
+MANIFEST_FILE = "processed_files.json"
+INDEX_NAME = "fabrikam-rag-index"
+ANALYZER_ID = "fabrikam_document_analyzer"
+DATA_FOLDER = "data"
+POLL_INTERVAL = 30  # seconds between polls in watch mode
+EMBEDDING_DIMENSIONS = 3072  # text-embedding-3-large
+# ---------------------------------------------------------------------------
+
+
+def log(message):
+    """Print a timestamped log message."""
+    timestamp = datetime.now().strftime("%H:%M:%S")
+    print(f"[{timestamp}] {message}")
+
+
+def openai_base_url(foundry_endpoint):
+    """Build the Azure OpenAI v1 base URL from a Foundry resource endpoint."""
+    endpoint = (foundry_endpoint or "").rstrip("/")
+    if endpoint.endswith("/openai/v1"):
+        return endpoint + "/"
+    return f"{endpoint}/openai/v1/"
+
+
+# -- Manifest helpers -------------------------------------------------------
+
+def load_manifest():
+    """Load the manifest that tracks which files have been processed."""
+    if os.path.exists(MANIFEST_FILE):
+        with open(MANIFEST_FILE, "r") as f:
+            return json.load(f)
+    return {}
+
+
+def save_manifest(manifest):
+    """Save the processed-files manifest to disk."""
+    with open(MANIFEST_FILE, "w") as f:
+        json.dump(manifest, f, indent=2)
+
+
+def file_hash(file_path):
+    """Compute a SHA-256 hash of a file for change detection."""
+    sha = hashlib.sha256()
+    with open(file_path, "rb") as f:
+        for block in iter(lambda: f.read(8192), b""):
+            sha.update(block)
+    return sha.hexdigest()
+
+
+# -- File discovery ---------------------------------------------------------
+
+def get_pending_files(manifest):
+    """Return a list of files that are new or have changed since last run."""
+    supported = ["*.pdf", "*.png", "*.jpg", "*.docx", "*.txt"]
+    all_files = []
+    for pattern in supported:
+        all_files.extend(glob.glob(os.path.join(DATA_FOLDER, pattern)))
+
+    pending = []
+    for fp in all_files:
+        current_hash = file_hash(fp)
+        if manifest.get(fp) != current_hash:
+            pending.append(fp)
+    return pending
+
+
+# -- Search index -----------------------------------------------------------
+
+def ensure_index(search_endpoint, search_key):
+    """Create or update the Azure AI Search index."""
+    index_client = SearchIndexClient(
+        endpoint=search_endpoint,
+        credential=AzureKeyCredential(search_key),
+    )
+
+    fields = [
+        SimpleField(
+            name="id", type=SearchFieldDataType.String,
+            key=True, filterable=True
+        ),
+        SearchableField(name="content", type=SearchFieldDataType.String),
+        SimpleField(
+            name="file_name", type=SearchFieldDataType.String, filterable=True
+        ),
+        SearchableField(name="summary", type=SearchFieldDataType.String),
+        SearchableField(name="key_topics", type=SearchFieldDataType.String),
+        SearchField(
+            name="content_vector",
+            type=SearchFieldDataType.Collection(SearchFieldDataType.Single),
+            searchable=True,
+            vector_search_dimensions=EMBEDDING_DIMENSIONS,
+            vector_search_profile_name="vector-profile",
+        ),
+    ]
+
+    vector_search = VectorSearch(
+        algorithms=[HnswAlgorithmConfiguration(name="hnsw-algorithm")],
+        profiles=[
+            VectorSearchProfile(
+                name="vector-profile",
+                algorithm_configuration_name="hnsw-algorithm",
+            )
+        ],
+    )
+
+    index = SearchIndex(name=INDEX_NAME, fields=fields, vector_search=vector_search)
+    index_client.create_or_update_index(index)
+
+
+# -- Content chunking -------------------------------------------------------
+
+def chunk_content(text, max_chars=2000):
+    """Split text into chunks at paragraph boundaries."""
+    paragraphs = text.split("\n\n")
+    chunks, current = [], ""
+
+    for para in paragraphs:
+        para = para.strip()
+        if not para:
+            continue
+        if len(current) + len(para) + 2 > max_chars and current:
+            chunks.append(current.strip())
+            current = para
+        else:
+            current += ("\n\n" + para) if current else para
+
+    if current.strip():
+        chunks.append(current.strip())
+
+    return chunks if chunks else [text[:max_chars]]
+
+
+def make_doc_id(file_name, chunk_index):
+    """Generate a deterministic document ID from the file name and chunk."""
+    raw = f"{file_name}::{chunk_index}"
+    return hashlib.md5(raw.encode()).hexdigest()
+
+
+# -- Ingestion logic --------------------------------------------------------
+
+def ingest_file(file_path, cu_client, openai_client, search_client,
+                embedding_deployment):
+    """Extract, embed, and index a single file.
+
+    Returns the number of chunks successfully indexed.
+    """
+    file_name = os.path.basename(file_path)
+
+    # --- Extract with Content Understanding ---------------------------------
+    with open(file_path, "rb") as f:
+        file_data = f.read()
+
+    poller = cu_client.begin_analyze_binary(
+        analyzer_id=ANALYZER_ID,
+        binary_input=file_data,
+    )
+    result = poller.result()
+
+    doc_content = ""
+    fields = {}
+    for item in result.contents:
+        if hasattr(item, "markdown") and item.markdown:
+            doc_content += item.markdown + "\n"
+        if hasattr(item, "fields") and item.fields:
+            for name, data in item.fields.items():
+                if hasattr(data, "value_array") and data.value_array is not None:
+                    fields[name] = [v.get("value", str(v)) for v in data.value_array]
+                elif hasattr(data, "value"):
+                    fields[name] = data.value
+
+    if not doc_content.strip():
+        log("    Skipped (no extractable content).")
+        return 0
+
+    # --- Chunk, embed, and index -------------------------------------------
+    chunks = chunk_content(doc_content)
+    summary = fields.get("Summary", "")
+    key_topics = (
+        ", ".join(fields.get("KeyTopics", []))
+        if isinstance(fields.get("KeyTopics"), list)
+        else str(fields.get("KeyTopics", ""))
+    )
+
+    docs_to_upload = []
+    for j, chunk in enumerate(chunks):
+        log(f"    Embedding chunk {j + 1}/{len(chunks)}...")
+        resp = openai_client.embeddings.create(
+            input=chunk, model=embedding_deployment
+        )
+        embedding = resp.data[0].embedding
+
+        docs_to_upload.append({
+            "id": make_doc_id(file_name, j),
+            "content": chunk,
+            "file_name": file_name,
+            "summary": str(summary) if not isinstance(summary, str) else summary,
+            "key_topics": key_topics,
+            "content_vector": embedding,
+        })
+
+    if docs_to_upload:
+        upload_result = search_client.upload_documents(documents=docs_to_upload)
+        succeeded = sum(1 for r in upload_result if r.succeeded)
+        log(f"    Indexed {succeeded} chunk(s) from {file_name}.")
+        return succeeded
+
+    return 0
+
+
+def run_ingestion(cu_client, openai_client, search_client,
+                  embedding_deployment, manifest):
+    """Process any new or updated files. Returns True if files were ingested."""
+    pending = get_pending_files(manifest)
+    if not pending:
+        return False
+
+    log(f"Detected {len(pending)} new/updated file(s).")
+    total_chunks = 0
+
+    for file_path in pending:
+        log(f"  Processing: {os.path.basename(file_path)}")
+        chunks = ingest_file(
+            file_path, cu_client, openai_client, search_client,
+            embedding_deployment,
+        )
+        total_chunks += chunks
+
+        # Mark the file as processed immediately after successful ingestion
+        manifest[file_path] = file_hash(file_path)
+        save_manifest(manifest)
+
+    log(f"Ingestion complete - {len(pending)} file(s), "
+        f"{total_chunks} chunk(s) indexed.\n")
+    return True
+
+
+# -- Entry point ------------------------------------------------------------
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Automated RAG ingestion pipeline"
+    )
+    parser.add_argument(
+        "--watch", action="store_true",
+        help="Continuously watch for new files "
+             f"(polls every {POLL_INTERVAL} seconds)",
+    )
+    parser.add_argument(
+        "--reset", action="store_true",
+        help="Clear processed-file tracking and reprocess everything",
+    )
+    args = parser.parse_args()
+
+    os.system("cls" if os.name == "nt" else "clear")
+
+    # Load environment configuration
+    load_dotenv()
+    foundry_endpoint = os.getenv("FOUNDRY_ENDPOINT")
+    foundry_key = os.getenv("FOUNDRY_KEY")
+    embedding_deployment = os.getenv("EMBEDDING_DEPLOYMENT_NAME")
+    search_endpoint = os.getenv("SEARCH_ENDPOINT")
+    search_key = os.getenv("SEARCH_ADMIN_KEY")
+
+    # Create SDK clients
+    cu_client = ContentUnderstandingClient(
+        endpoint=foundry_endpoint, credential=AzureKeyCredential(foundry_key),
+    )
+    openai_client = OpenAI(
+        api_key=foundry_key,
+        base_url=openai_base_url(foundry_endpoint),
+    )
+    search_client = SearchClient(
+        endpoint=search_endpoint,
+        index_name=INDEX_NAME,
+        credential=AzureKeyCredential(search_key),
+    )
+
+    # Ensure the search index exists
+    log("Verifying search index...")
+    ensure_index(search_endpoint, search_key)
+    log(f"Search index '{INDEX_NAME}' is ready.")
+
+    # Handle --reset flag
+    if args.reset and os.path.exists(MANIFEST_FILE):
+        os.remove(MANIFEST_FILE)
+        log("Cleared processed-file tracking - all files will be reprocessed.")
+
+    manifest = load_manifest()
+
+    if args.watch:
+        log(f"Watching '{DATA_FOLDER}/' for new documents "
+            f"(press Ctrl+C to stop)...\n")
+        try:
+            while True:
+                found = run_ingestion(
+                    cu_client, openai_client, search_client,
+                    embedding_deployment, manifest,
+                )
+                if not found:
+                    log("No new files. Waiting...")
+                time.sleep(POLL_INTERVAL)
+        except KeyboardInterrupt:
+            print("\nStopped watching.")
+    else:
+        found = run_ingestion(
+            cu_client, openai_client, search_client,
+            embedding_deployment, manifest,
+        )
+        if not found:
+            log("No new files to ingest - all documents are up to date.")
+
+
+if __name__ == "__main__":
+    main()

--- a/Labfiles/B-make-extracted-information-searchable/Python/rag-agent.py
+++ b/Labfiles/B-make-extracted-information-searchable/Python/rag-agent.py
@@ -1,0 +1,145 @@
+"""Task 3 - answer questions about the Fabrikam Logistics document set.
+
+Retrieves the most relevant indexed content with hybrid search (keyword +
+vector), then asks a chat model to answer using only that content.
+"""
+
+from dotenv import load_dotenv
+import os
+from openai import OpenAI
+from azure.core.credentials import AzureKeyCredential
+from azure.search.documents import SearchClient
+from azure.search.documents.models import VectorizedQuery
+
+INDEX_NAME = "fabrikam-rag-index"
+
+
+def openai_base_url(foundry_endpoint):
+    """Build the Azure OpenAI v1 base URL from a Foundry resource endpoint."""
+    endpoint = (foundry_endpoint or "").rstrip("/")
+    if endpoint.endswith("/openai/v1"):
+        return endpoint + "/"
+    return f"{endpoint}/openai/v1/"
+
+
+def main():
+    """RAG agent that answers questions using retrieved content from Azure AI Search."""
+
+    # Clear the console
+    os.system('cls' if os.name == 'nt' else 'clear')
+
+    try:
+        # Get config settings
+        load_dotenv()
+        foundry_endpoint = os.getenv('FOUNDRY_ENDPOINT')
+        foundry_key = os.getenv('FOUNDRY_KEY')
+        chat_deployment = os.getenv('CHAT_DEPLOYMENT_NAME')
+        embedding_deployment = os.getenv('EMBEDDING_DEPLOYMENT_NAME')
+        search_endpoint = os.getenv('SEARCH_ENDPOINT')
+        search_key = os.getenv('SEARCH_ADMIN_KEY')
+
+        # Create clients
+        openai_client = OpenAI(
+            api_key=foundry_key,
+            base_url=openai_base_url(foundry_endpoint),
+        )
+
+        search_client = SearchClient(
+            endpoint=search_endpoint,
+            index_name=INDEX_NAME,
+            credential=AzureKeyCredential(search_key)
+        )
+
+        print("RAG agent ready. Ask questions about your indexed documents.")
+        print("Type 'quit' to exit.\n")
+
+        # Conversation loop
+        while True:
+            question = input("You: ").strip()
+            if question.lower() == "quit":
+                print("Goodbye!")
+                break
+            if not question:
+                continue
+
+            # Retrieve relevant content using hybrid search
+            context = retrieve_context(
+                question, search_client, openai_client, embedding_deployment
+            )
+
+            # Generate a response using the chat model
+            answer = generate_answer(
+                question, context, openai_client, chat_deployment
+            )
+
+            print(f"\nAssistant: {answer}\n")
+
+    except Exception as ex:
+        print(f"Error: {ex}")
+
+
+def retrieve_context(question, search_client, openai_client, embedding_deployment, top_k=3):
+    """Perform hybrid search (keyword + vector) to retrieve relevant content chunks."""
+
+    # Generate embedding for the question
+    embedding_response = openai_client.embeddings.create(
+        input=question,
+        model=embedding_deployment
+    )
+    query_vector = embedding_response.data[0].embedding
+
+    # Perform hybrid search
+    vector_query = VectorizedQuery(
+        vector=query_vector,
+        k_nearest_neighbors=top_k,
+        fields="content_vector"
+    )
+
+    results = search_client.search(
+        search_text=question,
+        vector_queries=[vector_query],
+        select=["content", "file_name", "summary"],
+        top=top_k
+    )
+
+    # Build context from results
+    context_parts = []
+    for result in results:
+        source = result.get("file_name", "Unknown")
+        content = result.get("content", "")
+        if content:
+            context_parts.append(f"[Source: {source}]\n{content}")
+
+    return "\n\n---\n\n".join(context_parts) if context_parts else ""
+
+
+def generate_answer(question, context, openai_client, chat_deployment):
+    """Generate an answer using the chat model with retrieved context."""
+
+    if not context:
+        system_message = (
+            "You are a helpful assistant. The user asked a question but no "
+            "relevant documents were found in the knowledge base. Let the user know."
+        )
+    else:
+        system_message = (
+            "You are a helpful assistant that answers questions based on the provided context. "
+            "Use only the information from the context to answer. If the context doesn't contain "
+            "enough information to fully answer the question, say so. "
+            "Cite the source document names when possible.\n\n"
+            f"Context:\n{context}"
+        )
+
+    response = openai_client.chat.completions.create(
+        model=chat_deployment,
+        messages=[
+            {"role": "system", "content": system_message},
+            {"role": "user", "content": question}
+        ]
+    )
+
+    return response.choices[0].message.content
+
+
+if __name__ == "__main__":
+    main()

--- a/Labfiles/B-make-extracted-information-searchable/Python/requirements.txt
+++ b/Labfiles/B-make-extracted-information-searchable/Python/requirements.txt
@@ -1,0 +1,4 @@
+python-dotenv==1.2.2
+azure-ai-contentunderstanding==1.1.0
+azure-search-documents==11.6.0
+openai==1.109.1

--- a/Labfiles/B-make-extracted-information-searchable/Python/search-app.py
+++ b/Labfiles/B-make-extracted-information-searchable/Python/search-app.py
@@ -1,0 +1,69 @@
+"""Task 1 - search the Fabrikam Logistics knowledge mining index.
+
+Queries the Azure AI Search index that the portal Import data wizard built,
+and prints the enriched fields that the AI skills extracted from each document.
+"""
+
+from dotenv import load_dotenv
+import os
+from azure.core.credentials import AzureKeyCredential
+from azure.search.documents import SearchClient
+
+
+def main():
+
+    # Clear the console
+    os.system('cls' if os.name == 'nt' else 'clear')
+
+    try:
+
+        # Get config settings
+        load_dotenv()
+        search_endpoint = os.getenv('SEARCH_ENDPOINT')
+        query_key = os.getenv('SEARCH_QUERY_KEY')
+        index = os.getenv('SEARCH_INDEX_NAME')
+
+        # Get a search client
+        search_client = SearchClient(search_endpoint, index, AzureKeyCredential(query_key))
+
+        # Loop until the user types 'quit'
+        while True:
+            # Get query text
+            query_text = input("Enter a query (or type 'quit' to exit): ")
+            if query_text.lower() == "quit":
+                break
+            if len(query_text) == 0:
+                print("Please enter a query.")
+                continue
+
+            # Clear the console
+            os.system('cls' if os.name == 'nt' else 'clear')
+
+            # Search the index
+            found_documents = search_client.search(
+                search_text=query_text,
+                select=["title", "locations", "persons", "keyPhrases"],
+                order_by=["title"],
+                include_total_count=True
+            )
+
+            # Parse the results
+            print(f"\nSearch returned {found_documents.get_count()} documents:")
+            for document in found_documents:
+                print(f"\nDocument: {document['title']}")
+                print(" - Locations:")
+                for location in document["locations"]:
+                    print(f"   - {location}")
+                print(" - People:")
+                for person in document["persons"]:
+                    print(f"   - {person}")
+                print(" - Key phrases:")
+                for phrase in document["keyPhrases"]:
+                    print(f"   - {phrase}")
+
+    except Exception as ex:
+        print(ex)
+
+
+if __name__ == "__main__":
+    main()

--- a/Labfiles/B-make-extracted-information-searchable/Solution/README.md
+++ b/Labfiles/B-make-extracted-information-searchable/Solution/README.md
@@ -1,0 +1,83 @@
+# Lab B solution - Make extracted information searchable
+
+Reference notes for the **Make extracted information searchable** lab.
+
+> **This lab has no fill-in-the-blanks.** Its source exercises were
+> review-and-run: you read each script, understand what it does, and run it.
+> So `../Python/` ships the complete, working implementation and there is no
+> separate `Solution/Python/` tree to compare against. (Lab A is the
+> write-the-code lab in this family - it has starter TODOs and a matching
+> `Solution/Python/`.)
+
+## File tree
+
+```
+Labfiles/B-make-extracted-information-searchable/
+  Python/                  complete, runnable code for every task
+    .env.example           copy to .env and fill in
+    requirements.txt
+    search-app.py          Task 1 - query the knowledge mining index
+    create-analyzer.py     Task 2 - register the ingestion analyzer
+    ingest-pipeline.py     Tasks 2 and 4 - extract, embed, index (+ --watch)
+    rag-agent.py           Tasks 3 and 4 - answer questions over the index
+    data/                  put the sample documents here
+  Solution/
+    README.md              this file
+  setup/
+    check_env.py           preflight check: python setup/check_env.py --task N
+```
+
+## How to run each task
+
+All commands run from `Labfiles/B-make-extracted-information-searchable/Python`
+with the virtual environment activated:
+
+```
+python -m venv labenv
+.\labenv\Scripts\Activate.ps1
+pip install -r requirements.txt
+```
+
+| Task | Command | Needs in `.env` |
+| --- | --- | --- |
+| Task 1 | `python search-app.py` | `SEARCH_ENDPOINT`, `SEARCH_QUERY_KEY`, `SEARCH_INDEX_NAME` |
+| Task 2 | `python create-analyzer.py` then `python ingest-pipeline.py` | `FOUNDRY_*`, `EMBEDDING_DEPLOYMENT_NAME`, `SEARCH_ENDPOINT`, `SEARCH_ADMIN_KEY` |
+| Task 3 | `python rag-agent.py` | adds `CHAT_DEPLOYMENT_NAME` |
+| Task 4 | `python ingest-pipeline.py --watch` in one terminal, `python rag-agent.py` in another | same as Task 3 |
+
+Before starting a task, check you have what it needs (run from the `Python` folder):
+
+```
+python ../setup/check_env.py --task 2
+```
+
+## How the pieces fit together
+
+- **Task 1** uses an index built by the Azure AI Search **Import data** wizard.
+  The wizard's AI skills enrich each document with `locations`, `persons`, and
+  `keyPhrases`, and `search-app.py` reads those fields back.
+- **Tasks 2-4** build a *second*, different index (`fabrikam-rag-index`) in
+  code. This one holds chunked content plus a 3072-dimension embedding vector,
+  which is what makes hybrid (keyword + vector) retrieval possible.
+- The two indexes live side by side in the same search resource. Task 1 needs
+  only a query key; Tasks 2-4 create and write an index, so they need an admin
+  key.
+
+## Notes
+
+- **Two keys, one resource.** `SEARCH_QUERY_KEY` is read-only and is all Task 1
+  needs. `SEARCH_ADMIN_KEY` is required to create and populate an index.
+- **Embedding dimensions must match.** `ingest-pipeline.py` sets
+  `EMBEDDING_DIMENSIONS = 3072` for `text-embedding-3-large`. If you deploy a
+  different embedding model, change that constant and delete the index so it
+  gets recreated with the right vector width.
+- **Azure OpenAI v1 API.** The scripts use the `OpenAI` client pointed at
+  `<your-foundry-endpoint>/openai/v1/`, which is the current GA pattern and
+  needs no dated `api-version`. See
+  [Azure OpenAI v1 API](https://learn.microsoft.com/azure/foundry/openai/api-version-lifecycle).
+- **API keys.** These tasks authenticate with resource keys because that's the
+  quickest path in a lab. For production, Microsoft recommends Microsoft Entra
+  ID with `DefaultAzureCredential` - see
+  [Azure AI Search RBAC](https://learn.microsoft.com/azure/search/search-security-rbac).
+- **`processed_files.json`** is created by the pipeline to track which files it
+  has already ingested. Delete it (or run `--reset`) to reprocess everything.

--- a/Labfiles/B-make-extracted-information-searchable/Solution/README.md
+++ b/Labfiles/B-make-extracted-information-searchable/Solution/README.md
@@ -24,7 +24,7 @@ Labfiles/B-make-extracted-information-searchable/
   Solution/
     README.md              this file
   setup/
-    check_env.py           preflight check: python setup/check_env.py --task N
+    check_env.py           preflight check: python ../setup/check_env.py --task N
 ```
 
 ## How to run each task
@@ -45,7 +45,8 @@ pip install -r requirements.txt
 | Task 3 | `python rag-agent.py` | adds `CHAT_DEPLOYMENT_NAME` |
 | Task 4 | `python ingest-pipeline.py --watch` in one terminal, `python rag-agent.py` in another | same as Task 3 |
 
-Before starting a task, check you have what it needs (run from the `Python` folder):
+Before starting a task, check you have what it needs. Run this from the lab's
+`Python/` folder (this lab has only one — there is no `Solution/Python/`):
 
 ```
 python ../setup/check_env.py --task 2

--- a/Labfiles/B-make-extracted-information-searchable/setup/check_env.py
+++ b/Labfiles/B-make-extracted-information-searchable/setup/check_env.py
@@ -26,10 +26,14 @@ import os
 from pathlib import Path
 
 # Escape sequences a quoted value decodes. Double quotes decode the full
-# set; single quotes decode only the delimiter and the backslash itself -
-# everything else stays literal. Measured against python-dotenv, not
+# C-style set; single quotes decode only the delimiter and the backslash
+# itself - everything else stays literal. Measured against python-dotenv, not
 # assumed: 'raw \n stays' keeps the backslash, but 'a\'b' yields a'b.
-_ESCAPES_DOUBLE = {"n": "\n", "r": "\r", "t": "\t", "\\": "\\", '"': '"', "'": "'"}
+_ESCAPES_DOUBLE = {
+    "n": "\n", "r": "\r", "t": "\t",
+    "a": "\a", "b": "\b", "f": "\f", "v": "\v",
+    "\\": "\\", '"': '"', "'": "'",
+}
 _ESCAPES_SINGLE = {"\\": "\\", "'": "'"}
 
 # Kept for callers/tests that reference the original name.

--- a/Labfiles/B-make-extracted-information-searchable/setup/check_env.py
+++ b/Labfiles/B-make-extracted-information-searchable/setup/check_env.py
@@ -43,6 +43,8 @@ except ImportError:
                     if line.startswith("export "):
                         line = line[len("export "):].lstrip()
                     if "=" not in line:
+                        # python-dotenv records a bare key with no '=' as None.
+                        values[line] = None
                         continue
                     key, _, value = line.partition("=")
                     key = key.strip()

--- a/Labfiles/B-make-extracted-information-searchable/setup/check_env.py
+++ b/Labfiles/B-make-extracted-information-searchable/setup/check_env.py
@@ -25,7 +25,15 @@ import argparse
 import os
 from pathlib import Path
 
-_ESCAPES = {"n": "\n", "r": "\r", "t": "\t", "\\": "\\", '"': '"', "'": "'"}
+# Escape sequences a quoted value decodes. Double quotes decode the full
+# set; single quotes decode only the delimiter and the backslash itself -
+# everything else stays literal. Measured against python-dotenv, not
+# assumed: 'raw \n stays' keeps the backslash, but 'a\'b' yields a'b.
+_ESCAPES_DOUBLE = {"n": "\n", "r": "\r", "t": "\t", "\\": "\\", '"': '"', "'": "'"}
+_ESCAPES_SINGLE = {"\\": "\\", "'": "'"}
+
+# Kept for callers/tests that reference the original name.
+_ESCAPES = _ESCAPES_DOUBLE
 
 
 def _has_utf8_bom(path):
@@ -186,17 +194,21 @@ def _parse_env_file(path):
 
         if value[:1] in ("'", '"'):
             quote = value[0]
+            escapes = _ESCAPES_DOUBLE if quote == '"' else _ESCAPES_SINGLE
             chars = []
             index = 1
             closed = False
             while index < len(value):
                 char = value[index]
-                # Only double quotes process backslash escapes, so a \" does
-                # not end the value and \n becomes a real newline. Decoding
-                # happens in this single pass so an escaped backslash isn't
-                # re-processed.
-                if quote == '"' and char == "\\" and index + 1 < len(value):
-                    chars.append(_ESCAPES.get(value[index + 1], "\\" + value[index + 1]))
+                # Both quote styles honour a backslash escape, but they decode
+                # different sets: a \" does not end a double-quoted value and
+                # \n becomes a newline, while a single-quoted value decodes
+                # only \' and \\ and leaves every other escape literal.
+                # Decoding happens in this single pass so an escaped backslash
+                # isn't re-processed.
+                if char == "\\" and index + 1 < len(value):
+                    nxt = value[index + 1]
+                    chars.append(escapes.get(nxt, "\\" + nxt))
                     index += 2
                     continue
                 if char == quote:

--- a/Labfiles/B-make-extracted-information-searchable/setup/check_env.py
+++ b/Labfiles/B-make-extracted-information-searchable/setup/check_env.py
@@ -25,39 +25,58 @@ import argparse
 import os
 from pathlib import Path
 
+def _parse_env_file(path):
+    """Minimal .env reader used when python-dotenv isn't installed.
+
+    Defined at module level (rather than inside the ImportError branch below)
+    so it can be imported and tested directly even when python-dotenv is
+    available. Its output matches dotenv.dotenv_values for the .env syntax
+    these labs use.
+    """
+    values = {}
+    try:
+        with open(path, "r", encoding="utf-8-sig") as handle:
+            for raw_line in handle:
+                line = raw_line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                # Strip 'export ' before splitting, so the key is the real
+                # name and not 'export KEY'.
+                if line.startswith("export "):
+                    line = line[len("export "):].lstrip()
+                if "=" not in line:
+                    # python-dotenv records a bare key with no '=' as None.
+                    values[line] = None
+                    continue
+                key, _, value = line.partition("=")
+                key = key.strip()
+                value = value.strip()
+                if value[:1] in ("'", '"'):
+                    # Quoted: take what's inside the quotes, so a '#' inside
+                    # is kept and a trailing comment outside is dropped.
+                    quote = value[0]
+                    end = value.find(quote, 1)
+                    if end == -1:
+                        # Unterminated quote; python-dotenv drops the key.
+                        continue
+                    value = value[1:end]
+                else:
+                    value = value.split(" #", 1)[0].strip()
+                if key:
+                    values[key] = value
+    except OSError:
+        return {}
+    return values
+
+
 try:
+    # python-dotenv is installed into the lab's virtual environment, but this
+    # preflight check is meant to run BEFORE 'pip install -r requirements.txt'
+    # (and Task 1 is portal-only, so that install may never happen), so fall
+    # back to the stdlib parser above when it isn't importable.
     from dotenv import dotenv_values
 except ImportError:
-    # python-dotenv is installed into the lab's virtual environment, but this
-    # preflight check is meant to run BEFORE 'pip install -r requirements.txt'.
-    # Fall back to a small standard-library parser so the check always works.
-    def dotenv_values(path):
-        """Minimal .env reader used when python-dotenv isn't installed."""
-        values = {}
-        try:
-            with open(path, "r", encoding="utf-8-sig") as handle:
-                for raw_line in handle:
-                    line = raw_line.strip()
-                    if not line or line.startswith("#"):
-                        continue
-                    if line.startswith("export "):
-                        line = line[len("export "):].lstrip()
-                    if "=" not in line:
-                        # python-dotenv records a bare key with no '=' as None.
-                        values[line] = None
-                        continue
-                    key, _, value = line.partition("=")
-                    key = key.strip()
-                    value = value.strip()
-                    if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
-                        value = value[1:-1]
-                    else:
-                        value = value.split(" #", 1)[0].strip()
-                    if key:
-                        values[key] = value
-        except OSError:
-            return {}
-        return values
+    dotenv_values = _parse_env_file
 
 RAG_KEYS = [
     "FOUNDRY_ENDPOINT",

--- a/Labfiles/B-make-extracted-information-searchable/setup/check_env.py
+++ b/Labfiles/B-make-extracted-information-searchable/setup/check_env.py
@@ -3,9 +3,10 @@ Preflight check for the Fabrikam Logistics "Make extracted information
 searchable" lab (Lab B).
 
 Each task in this lab can be completed on its own. Before you start a task,
-run this script to confirm your .env file has everything that task needs:
+run this script from the lab's `Python` folder to confirm your .env file has
+everything that task needs:
 
-    python setup/check_env.py --task 1
+    python ../setup/check_env.py --task 1
 
 It never changes anything - it only reads your .env and tells you what (if
 anything) is missing, so you can fix it before running the task.

--- a/Labfiles/B-make-extracted-information-searchable/setup/check_env.py
+++ b/Labfiles/B-make-extracted-information-searchable/setup/check_env.py
@@ -125,6 +125,29 @@ def _unterminated_hint(line_number, eaten):
     )
 
 
+def _find_closing_line(lines, start, quote, honor_escapes):
+    """Index of the first line at/after `start` containing an unescaped quote.
+
+    Returns None if there isn't one. Note that while recovering from an
+    unterminated value python-dotenv honours backslash escapes for BOTH quote
+    characters, even though single-quoted values are otherwise literal.
+    """
+    index = start
+    while index < len(lines):
+        line = lines[index]
+        position = 0
+        while position < len(line):
+            char = line[position]
+            if honor_escapes and char == "\\" and position + 1 < len(line):
+                position += 2
+                continue
+            if char == quote:
+                return index
+            position += 1
+        index += 1
+    return None
+
+
 def _parse_env_file(path):
     """Minimal .env reader used when python-dotenv isn't installed.
 
@@ -184,14 +207,16 @@ def _parse_env_file(path):
 
             if not closed:
                 # python-dotenv treats this as the start of a multi-line
-                # value and scans ahead for the matching quote. If it finds
-                # one, every line up to it is swallowed and the keys on those
-                # lines never reach the app; if it doesn't, only this line is
-                # dropped. Either way the malformed entry itself is discarded.
-                lookahead = position
-                while lookahead < len(lines) and quote not in lines[lookahead]:
-                    lookahead += 1
-                if lookahead < len(lines):
+                # value and scans ahead for the matching quote. It is
+                # escape-aware while doing so, but if no escaped-quote-aware
+                # close exists anywhere it retries treating every quote
+                # character literally - so an escaped quote can still end the
+                # recovery when it's the only candidate. Neither pass alone
+                # reproduces both behaviours.
+                lookahead = _find_closing_line(lines, position, quote, True)
+                if lookahead is None:
+                    lookahead = _find_closing_line(lines, position, quote, False)
+                if lookahead is not None:
                     position = lookahead + 1
                 continue
 

--- a/Labfiles/B-make-extracted-information-searchable/setup/check_env.py
+++ b/Labfiles/B-make-extracted-information-searchable/setup/check_env.py
@@ -168,6 +168,17 @@ def _parse_env_file(path):
     available. Its output matches dotenv.dotenv_values, including the awkward
     cases, because this check has to agree with what the app will actually
     see at runtime - the app reads the same file with python-dotenv.
+
+    INTENTIONAL DIVERGENCE - do not "fix" this to match dotenv:
+        This reads with utf-8-sig, so a UTF-8 BOM is stripped and the first
+        key parses under its real name. python-dotenv does NOT do that - it
+        returns the first key as "\\ufeffNAME". The difference is deliberate:
+        it lets the per-key report stay readable, and the BOM is caught
+        separately by _has_utf8_bom(), which forces the check to fail with an
+        explanation. Removing the strip to gain byte-parity with dotenv would
+        make the per-key output confusing without adding any safety, because
+        the safety lives in the detector, not in the parser. A parser-level
+        differential test cannot see this - assert it at check level instead.
     """
     try:
         with open(path, "r", encoding="utf-8-sig") as handle:
@@ -377,10 +388,49 @@ def load_values(env_path):
     return values
 
 
+def _placeholder_values():
+    """PLACEHOLDERS plus any placeholder-looking value in the shipped
+    .env.example, so the list can't silently rot when the example is edited.
+
+    Only values that *look* like placeholders are absorbed. .env.example also
+    ships real pre-filled values - an analyzer id, an index name, model names -
+    that a learner is meant to keep. Absorbing those would report a correctly
+    configured .env as MISSING, so the behavioural assertion to test is
+    "an unedited copy of .env.example is not ready", never "every value in
+    .env.example is a placeholder".
+    """
+    values = set(PLACEHOLDERS)
+    example = Path(__file__).resolve().parent.parent / "Python" / ".env.example"
+    try:
+        with open(example, "r", encoding="utf-8-sig") as handle:
+            for line in handle:
+                line = line.strip()
+                if not line or line.startswith("#") or "=" not in line:
+                    continue
+                value = line.partition("=")[2].strip()
+                lowered = value.lower()
+                if lowered.startswith("your_") or lowered.startswith("your-"):
+                    values.add(value)
+    except OSError:
+        pass
+    return values
+
+
+_PLACEHOLDER_CACHE = None
+
+
+def _all_placeholders():
+    """Cached placeholder set (PLACEHOLDERS unioned with the example file)."""
+    global _PLACEHOLDER_CACHE
+    if _PLACEHOLDER_CACHE is None:
+        _PLACEHOLDER_CACHE = _placeholder_values()
+    return _PLACEHOLDER_CACHE
+
+
 def is_set(values, key):
     """A key counts as set if it's present and not a leftover placeholder."""
     value = (values.get(key) or "").strip()
-    return bool(value) and value not in PLACEHOLDERS
+    return bool(value) and value not in _all_placeholders()
 
 
 def main():

--- a/Labfiles/B-make-extracted-information-searchable/setup/check_env.py
+++ b/Labfiles/B-make-extracted-information-searchable/setup/check_env.py
@@ -28,68 +28,157 @@ from pathlib import Path
 _ESCAPES = {"n": "\n", "r": "\r", "t": "\t", "\\": "\\", '"': '"', "'": "'"}
 
 
+def _has_utf8_bom(path):
+    """True if the file starts with a UTF-8 BOM.
+
+    Checked on the raw bytes, so the result is the same whether python-dotenv
+    or the fallback parser below did the reading.
+    """
+    try:
+        with open(path, "rb") as handle:
+            return handle.read(3) == b"\xef\xbb\xbf"
+    except OSError:
+        return False
+
+
+BOM_HINT = (
+    "Your .env was saved as 'UTF-8 with BOM' (Notepad does this by default). "
+    "The BOM becomes part of the first setting's name, so the app reads that "
+    "setting as empty even though the file looks correct. Re-save as plain "
+    "UTF-8: in VS Code, click the encoding in the status bar, choose 'Save "
+    "with Encoding', then 'UTF-8' (not 'UTF-8 with BOM')."
+)
+
+
+def _find_unterminated_quote(path):
+    """Return the 1-based line number of the first unterminated quoted value.
+
+    Read from the raw file, so the answer is the same whether python-dotenv or
+    the fallback parser did the reading. An unterminated quote is why a set of
+    otherwise-correct settings can vanish: python-dotenv keeps scanning for the
+    closing quote and swallows the lines it crosses, so the app never sees them.
+    """
+    try:
+        with open(path, "r", encoding="utf-8-sig") as handle:
+            for number, raw_line in enumerate(handle, start=1):
+                line = raw_line.strip()
+                if not line or line.startswith("#"):
+                    continue
+                if line.startswith("export "):
+                    line = line[len("export "):].lstrip()
+                if "=" not in line:
+                    continue
+                _, _, value = line.partition("=")
+                value = value.strip()
+                if value[:1] not in ("'", '"'):
+                    continue
+                quote = value[0]
+                index = 1
+                closed = False
+                while index < len(value):
+                    char = value[index]
+                    if quote == '"' and char == "\\" and index + 1 < len(value):
+                        index += 2
+                        continue
+                    if char == quote:
+                        closed = True
+                        break
+                    index += 1
+                if not closed:
+                    return number
+    except OSError:
+        return None
+    return None
+
+
+def _unterminated_hint(line_number):
+    return (
+        f"Line {line_number} of your .env opens a quote that is never closed. "
+        "python-dotenv keeps looking for the closing quote on the lines that "
+        "follow, so that setting - and potentially every setting after it - is "
+        f"read as one long value and never reaches the app. Close the quote on "
+        f"line {line_number} (or remove both quotes; these settings don't need "
+        "them)."
+    )
+
+
 def _parse_env_file(path):
     """Minimal .env reader used when python-dotenv isn't installed.
 
     Defined at module level (rather than inside the ImportError branch below)
     so it can be imported and tested directly even when python-dotenv is
-    available. Its output matches dotenv.dotenv_values for every well-formed
-    .env construct these labs use.
-
-    One intentional deviation: python-dotenv treats an unterminated quote as
-    the start of a multi-line value, so it swallows the following lines and
-    the keys defined on them silently disappear. This parser instead drops
-    only the malformed line and keeps every later key, so a typo in one value
-    can't make unrelated settings look MISSING.
+    available. Its output matches dotenv.dotenv_values, including the awkward
+    cases, because this check has to agree with what the app will actually
+    see at runtime - the app reads the same file with python-dotenv.
     """
-    values = {}
     try:
         with open(path, "r", encoding="utf-8-sig") as handle:
-            for raw_line in handle:
-                line = raw_line.strip()
-                if not line or line.startswith("#"):
-                    continue
-                # Strip 'export ' before splitting, so the key is the real
-                # name and not 'export KEY'.
-                if line.startswith("export "):
-                    line = line[len("export "):].lstrip()
-                if "=" not in line:
-                    # python-dotenv records a bare key with no '=' as None.
-                    values[line] = None
-                    continue
-                key, _, value = line.partition("=")
-                key = key.strip()
-                value = value.strip()
-                if value[:1] in ("'", '"'):
-                    quote = value[0]
-                    chars = []
-                    index = 1
-                    closed = False
-                    while index < len(value):
-                        char = value[index]
-                        # Only double quotes process backslash escapes, so a
-                        # \" doesn't end the value and \n becomes a newline.
-                        if quote == '"' and char == "\\" and index + 1 < len(value):
-                            nxt = value[index + 1]
-                            chars.append(_ESCAPES.get(nxt, "\\" + nxt))
-                            index += 2
-                            continue
-                        if char == quote:
-                            closed = True
-                            break
-                        chars.append(char)
-                        index += 1
-                    if not closed:
-                        # Unterminated quote; python-dotenv drops the key.
-                        continue
-                    # Anything after the closing quote is a trailing comment.
-                    value = "".join(chars)
-                else:
-                    value = value.split(" #", 1)[0].strip()
-                if key:
-                    values[key] = value
+            lines = handle.readlines()
     except OSError:
         return {}
+
+    values = {}
+    position = 0
+    while position < len(lines):
+        line = lines[position].strip()
+        position += 1
+
+        if not line or line.startswith("#"):
+            continue
+        # Strip 'export ' before splitting, so the key is the real name and
+        # not 'export KEY'.
+        if line.startswith("export "):
+            line = line[len("export "):].lstrip()
+        if "=" not in line:
+            # python-dotenv records a bare key with no '=' as None.
+            values[line] = None
+            continue
+
+        key, _, value = line.partition("=")
+        key = key.strip()
+        value = value.strip()
+
+        if value[:1] in ("'", '"'):
+            quote = value[0]
+            chars = []
+            index = 1
+            closed = False
+            while index < len(value):
+                char = value[index]
+                # Only double quotes process backslash escapes, so a \" does
+                # not end the value and \n becomes a real newline. Decoding
+                # happens in this single pass so an escaped backslash isn't
+                # re-processed.
+                if quote == '"' and char == "\\" and index + 1 < len(value):
+                    chars.append(_ESCAPES.get(value[index + 1], "\\" + value[index + 1]))
+                    index += 2
+                    continue
+                if char == quote:
+                    closed = True
+                    break
+                chars.append(char)
+                index += 1
+
+            if not closed:
+                # python-dotenv treats this as the start of a multi-line
+                # value and scans ahead for the matching quote. If it finds
+                # one, every line up to it is swallowed and the keys on those
+                # lines never reach the app; if it doesn't, only this line is
+                # dropped. Either way the malformed entry itself is discarded.
+                lookahead = position
+                while lookahead < len(lines) and quote not in lines[lookahead]:
+                    lookahead += 1
+                if lookahead < len(lines):
+                    position = lookahead + 1
+                continue
+
+            value = "".join(chars)
+        else:
+            value = value.split(" #", 1)[0].strip()
+
+        if key:
+            values[key] = value
+
     return values
 
 
@@ -211,7 +300,13 @@ def load_values(env_path):
     """Merge real environment variables over .env file values (env wins)."""
     values = {}
     if env_path.exists():
-        values.update({k: v for k, v in dotenv_values(env_path).items() if v is not None})
+        for key, value in dotenv_values(env_path).items():
+            if value is None:
+                continue
+            # A UTF-8 BOM ends up glued to the first key's name. Strip it here
+            # so the per-key report is still readable; the BOM itself is
+            # reported separately as a problem, never silently accepted.
+            values[key.lstrip("\ufeff")] = value
     for key in ALL_KEYS:
         if os.environ.get(key):
             values[key] = os.environ[key]
@@ -240,10 +335,18 @@ def main():
     env_path = find_env_file()
     values = load_values(env_path)
     required = TASK_REQUIREMENTS[args.task]
+    has_bom = env_path.exists() and _has_utf8_bom(env_path)
+    bad_quote_line = _find_unterminated_quote(env_path) if env_path.exists() else None
 
     print(f"Checking readiness for Task {args.task}")
     print(f"Reading: {env_path}{'' if env_path.exists() else '  (not found yet)'}")
     print()
+
+    if not required:
+        print("  Task 1 runs entirely in the browser - no .env values needed.")
+        print()
+        print("You're ready to start Task 1.")
+        return 0
 
     missing = [key for key in required if not is_set(values, key)]
 
@@ -251,13 +354,25 @@ def main():
         mark = "OK " if is_set(values, key) else "MISSING"
         print(f"  [{mark}] {key}")
 
-    if not missing:
+    # These two break the app even when the keys look right, so neither is
+    # ever treated as "ready" - the app would fail after this said OK. They're
+    # also usually the root cause of the MISSING keys listed above.
+    if has_bom:
+        print("  [PROBLEM] .env starts with a UTF-8 BOM")
+    if bad_quote_line:
+        print(f"  [PROBLEM] .env line {bad_quote_line}: unterminated quote")
+
+    if not missing and not has_bom and not bad_quote_line:
         print()
         print(f"You're ready to start Task {args.task}.")
         return 0
 
     print()
-    print("Set the following before starting this task:")
+    print("Fix the following before starting this task:")
+    if has_bom:
+        print(f"\n  .env encoding\n    {BOM_HINT}")
+    if bad_quote_line:
+        print(f"\n  .env line {bad_quote_line}\n    {_unterminated_hint(bad_quote_line)}")
     for key in missing:
         print(f"\n  {key}\n    {FIX_HINTS.get(key, 'Add this key to your .env file.')}")
     return 1

--- a/Labfiles/B-make-extracted-information-searchable/setup/check_env.py
+++ b/Labfiles/B-make-extracted-information-searchable/setup/check_env.py
@@ -25,7 +25,37 @@ import argparse
 import os
 from pathlib import Path
 
-from dotenv import dotenv_values
+try:
+    from dotenv import dotenv_values
+except ImportError:
+    # python-dotenv is installed into the lab's virtual environment, but this
+    # preflight check is meant to run BEFORE 'pip install -r requirements.txt'.
+    # Fall back to a small standard-library parser so the check always works.
+    def dotenv_values(path):
+        """Minimal .env reader used when python-dotenv isn't installed."""
+        values = {}
+        try:
+            with open(path, "r", encoding="utf-8-sig") as handle:
+                for raw_line in handle:
+                    line = raw_line.strip()
+                    if not line or line.startswith("#"):
+                        continue
+                    if line.startswith("export "):
+                        line = line[len("export "):].lstrip()
+                    if "=" not in line:
+                        continue
+                    key, _, value = line.partition("=")
+                    key = key.strip()
+                    value = value.strip()
+                    if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+                        value = value[1:-1]
+                    else:
+                        value = value.split(" #", 1)[0].strip()
+                    if key:
+                        values[key] = value
+        except OSError:
+            return {}
+        return values
 
 RAG_KEYS = [
     "FOUNDRY_ENDPOINT",

--- a/Labfiles/B-make-extracted-information-searchable/setup/check_env.py
+++ b/Labfiles/B-make-extracted-information-searchable/setup/check_env.py
@@ -1,0 +1,191 @@
+"""
+Preflight check for the Fabrikam Logistics "Make extracted information
+searchable" lab (Lab B).
+
+Each task in this lab can be completed on its own. Before you start a task,
+run this script to confirm your .env file has everything that task needs:
+
+    python setup/check_env.py --task 1
+
+It never changes anything - it only reads your .env and tells you what (if
+anything) is missing, so you can fix it before running the task.
+
+Tasks and what they need:
+
+    Task 1  (code)   SEARCH_ENDPOINT, SEARCH_QUERY_KEY, SEARCH_INDEX_NAME
+    Task 2  (code)   FOUNDRY_ENDPOINT, FOUNDRY_KEY, EMBEDDING_DEPLOYMENT_NAME,
+                     SEARCH_ENDPOINT, SEARCH_ADMIN_KEY
+    Task 3  (code)   FOUNDRY_ENDPOINT, FOUNDRY_KEY, CHAT_DEPLOYMENT_NAME,
+                     EMBEDDING_DEPLOYMENT_NAME, SEARCH_ENDPOINT, SEARCH_ADMIN_KEY
+    Task 4  (code)   Same as Task 3 (watch mode ingests, then you re-query)
+"""
+
+import argparse
+import os
+from pathlib import Path
+
+from dotenv import dotenv_values
+
+RAG_KEYS = [
+    "FOUNDRY_ENDPOINT",
+    "FOUNDRY_KEY",
+    "CHAT_DEPLOYMENT_NAME",
+    "EMBEDDING_DEPLOYMENT_NAME",
+    "SEARCH_ENDPOINT",
+    "SEARCH_ADMIN_KEY",
+]
+
+# Which .env keys each task needs to run on its own.
+TASK_REQUIREMENTS = {
+    1: ["SEARCH_ENDPOINT", "SEARCH_QUERY_KEY", "SEARCH_INDEX_NAME"],
+    2: [
+        "FOUNDRY_ENDPOINT",
+        "FOUNDRY_KEY",
+        "EMBEDDING_DEPLOYMENT_NAME",
+        "SEARCH_ENDPOINT",
+        "SEARCH_ADMIN_KEY",
+    ],
+    3: RAG_KEYS,
+    4: RAG_KEYS,
+}
+
+# Every key this lab might read, used when merging real environment variables.
+ALL_KEYS = [
+    "SEARCH_ENDPOINT",
+    "SEARCH_QUERY_KEY",
+    "SEARCH_ADMIN_KEY",
+    "SEARCH_INDEX_NAME",
+    "FOUNDRY_ENDPOINT",
+    "FOUNDRY_KEY",
+    "CHAT_DEPLOYMENT_NAME",
+    "EMBEDDING_DEPLOYMENT_NAME",
+]
+
+# Placeholder text shipped in .env.example - present but not yet filled in.
+PLACEHOLDERS = {
+    "",
+    "your_search_endpoint",
+    "your_query_key",
+    "your_search_admin_key",
+    "your_index_name",
+    "your_foundry_endpoint",
+    "your_foundry_key",
+    "YOUR_ENDPOINT",
+    "YOUR_KEY",
+}
+
+# How to fix each key, shown only when it's missing.
+FIX_HINTS = {
+    "SEARCH_ENDPOINT": (
+        "Copy the Url from the Overview page of your Azure AI Search resource "
+        "in the Azure portal (for example https://your-search.search.windows.net), "
+        "then set SEARCH_ENDPOINT in .env."
+    ),
+    "SEARCH_QUERY_KEY": (
+        "In the Azure portal, open your Azure AI Search resource and go to "
+        "Settings > Keys. Copy the query key and set SEARCH_QUERY_KEY in .env. "
+        "The default query key can appear with a blank name - that's expected."
+    ),
+    "SEARCH_ADMIN_KEY": (
+        "Tasks 2-4 create and write to an index, so they need an admin key. "
+        "In the Azure portal, open your Azure AI Search resource, go to "
+        "Settings > Keys, and copy a primary or secondary admin key."
+    ),
+    "SEARCH_INDEX_NAME": (
+        "Set SEARCH_INDEX_NAME to the index the Import data wizard created, "
+        "for example fabrikam-index."
+    ),
+    "FOUNDRY_ENDPOINT": (
+        "Copy the Endpoint from the Overview page of your Microsoft Foundry "
+        "resource in the Azure portal, then set FOUNDRY_ENDPOINT in .env."
+    ),
+    "FOUNDRY_KEY": (
+        "Copy one of the keys from Resource Management > Keys and Endpoint on "
+        "your Microsoft Foundry resource, then set FOUNDRY_KEY in .env."
+    ),
+    "CHAT_DEPLOYMENT_NAME": (
+        "Set CHAT_DEPLOYMENT_NAME to the name of your deployed chat model. In "
+        "the Foundry portal, select Build > Deployments to see it. Deployment "
+        "names often have a numeric suffix, so copy it exactly."
+    ),
+    "EMBEDDING_DEPLOYMENT_NAME": (
+        "Set EMBEDDING_DEPLOYMENT_NAME to the name of your deployed embedding "
+        "model (text-embedding-3-large). Check Build > Deployments in the "
+        "Foundry portal and copy the name exactly, including any suffix."
+    ),
+}
+
+
+def find_env_file():
+    """Return the .env next to the lab's Python folder, wherever this is run from."""
+    here = Path(__file__).resolve().parent
+    candidates = [
+        Path.cwd() / ".env",
+        here.parent / "Python" / ".env",
+        here.parent / ".env",
+    ]
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    # Default to the Python-folder location even if it doesn't exist yet.
+    return here.parent / "Python" / ".env"
+
+
+def load_values(env_path):
+    """Merge real environment variables over .env file values (env wins)."""
+    values = {}
+    if env_path.exists():
+        values.update({k: v for k, v in dotenv_values(env_path).items() if v is not None})
+    for key in ALL_KEYS:
+        if os.environ.get(key):
+            values[key] = os.environ[key]
+    return values
+
+
+def is_set(values, key):
+    """A key counts as set if it's present and not a leftover placeholder."""
+    value = (values.get(key) or "").strip()
+    return bool(value) and value not in PLACEHOLDERS
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Check that your .env has what a given lab task needs."
+    )
+    parser.add_argument(
+        "--task",
+        type=int,
+        choices=sorted(TASK_REQUIREMENTS),
+        required=True,
+        help="Which task you're about to start (1-4).",
+    )
+    args = parser.parse_args()
+
+    env_path = find_env_file()
+    values = load_values(env_path)
+    required = TASK_REQUIREMENTS[args.task]
+
+    print(f"Checking readiness for Task {args.task}")
+    print(f"Reading: {env_path}{'' if env_path.exists() else '  (not found yet)'}")
+    print()
+
+    missing = [key for key in required if not is_set(values, key)]
+
+    for key in required:
+        mark = "OK " if is_set(values, key) else "MISSING"
+        print(f"  [{mark}] {key}")
+
+    if not missing:
+        print()
+        print(f"You're ready to start Task {args.task}.")
+        return 0
+
+    print()
+    print("Set the following before starting this task:")
+    for key in missing:
+        print(f"\n  {key}\n    {FIX_HINTS.get(key, 'Add this key to your .env file.')}")
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/Labfiles/B-make-extracted-information-searchable/setup/check_env.py
+++ b/Labfiles/B-make-extracted-information-searchable/setup/check_env.py
@@ -25,13 +25,22 @@ import argparse
 import os
 from pathlib import Path
 
+_ESCAPES = {"n": "\n", "r": "\r", "t": "\t", "\\": "\\", '"': '"', "'": "'"}
+
+
 def _parse_env_file(path):
     """Minimal .env reader used when python-dotenv isn't installed.
 
     Defined at module level (rather than inside the ImportError branch below)
     so it can be imported and tested directly even when python-dotenv is
-    available. Its output matches dotenv.dotenv_values for the .env syntax
-    these labs use.
+    available. Its output matches dotenv.dotenv_values for every well-formed
+    .env construct these labs use.
+
+    One intentional deviation: python-dotenv treats an unterminated quote as
+    the start of a multi-line value, so it swallows the following lines and
+    the keys defined on them silently disappear. This parser instead drops
+    only the malformed line and keeps every later key, so a typo in one value
+    can't make unrelated settings look MISSING.
     """
     values = {}
     try:
@@ -52,14 +61,29 @@ def _parse_env_file(path):
                 key = key.strip()
                 value = value.strip()
                 if value[:1] in ("'", '"'):
-                    # Quoted: take what's inside the quotes, so a '#' inside
-                    # is kept and a trailing comment outside is dropped.
                     quote = value[0]
-                    end = value.find(quote, 1)
-                    if end == -1:
+                    chars = []
+                    index = 1
+                    closed = False
+                    while index < len(value):
+                        char = value[index]
+                        # Only double quotes process backslash escapes, so a
+                        # \" doesn't end the value and \n becomes a newline.
+                        if quote == '"' and char == "\\" and index + 1 < len(value):
+                            nxt = value[index + 1]
+                            chars.append(_ESCAPES.get(nxt, "\\" + nxt))
+                            index += 2
+                            continue
+                        if char == quote:
+                            closed = True
+                            break
+                        chars.append(char)
+                        index += 1
+                    if not closed:
                         # Unterminated quote; python-dotenv drops the key.
                         continue
-                    value = value[1:end]
+                    # Anything after the closing quote is a trailing comment.
+                    value = "".join(chars)
                 else:
                     value = value.split(" #", 1)[0].strip()
                 if key:

--- a/Labfiles/B-make-extracted-information-searchable/setup/check_env.py
+++ b/Labfiles/B-make-extracted-information-searchable/setup/check_env.py
@@ -91,14 +91,37 @@ def _find_unterminated_quote(path):
     return None
 
 
-def _unterminated_hint(line_number):
+def _keys_written_in_file(path):
+    """Return the key names that physically appear as assignments in the file.
+
+    Used to tell a key that was never written from one that IS written but got
+    eaten by a malformation, so the check can report the difference honestly.
+    """
+    written = set()
+    try:
+        with open(path, "r", encoding="utf-8-sig") as handle:
+            for raw_line in handle:
+                line = raw_line.strip().lstrip("\ufeff")
+                if not line or line.startswith("#"):
+                    continue
+                if line.startswith("export "):
+                    line = line[len("export "):].lstrip()
+                if "=" not in line:
+                    continue
+                written.add(line.partition("=")[0].strip())
+    except OSError:
+        return written
+    return written
+
+
+def _unterminated_hint(line_number, eaten):
+    keys = ", ".join(eaten)
     return (
         f"Line {line_number} of your .env opens a quote that is never closed. "
         "python-dotenv keeps looking for the closing quote on the lines that "
-        "follow, so that setting - and potentially every setting after it - is "
-        f"read as one long value and never reaches the app. Close the quote on "
-        f"line {line_number} (or remove both quotes; these settings don't need "
-        "them)."
+        f"follow, so {keys} is in your file but never reaches the app. Close "
+        f"the quote on line {line_number} (or remove both quotes; these "
+        "settings don't need them)."
     )
 
 
@@ -349,20 +372,29 @@ def main():
         return 0
 
     missing = [key for key in required if not is_set(values, key)]
+    # A key that's written in the file but absent from the parsed result was
+    # eaten by the malformation - that's the difference between "you never set
+    # this" and "you set this and it isn't reaching the app".
+    written = _keys_written_in_file(env_path) if env_path.exists() else set()
+    eaten = [key for key in required if key in written and key not in values]
 
     for key in required:
         mark = "OK " if is_set(values, key) else "MISSING"
         print(f"  [{mark}] {key}")
 
-    # These two break the app even when the keys look right, so neither is
-    # ever treated as "ready" - the app would fail after this said OK. They're
-    # also usually the root cause of the MISSING keys listed above.
+    # A BOM always corrupts the first setting, so it's always fatal. An
+    # unterminated quote is only fatal when it actually ate something this
+    # task needs - a stray quote below the keys in use changes nothing, and
+    # failing the check for it would be its own false alarm.
     if has_bom:
         print("  [PROBLEM] .env starts with a UTF-8 BOM")
-    if bad_quote_line:
+    if bad_quote_line and eaten:
         print(f"  [PROBLEM] .env line {bad_quote_line}: unterminated quote")
+    elif bad_quote_line:
+        print(f"  [NOTE] .env line {bad_quote_line}: unterminated quote "
+              f"(nothing this task needs is affected)")
 
-    if not missing and not has_bom and not bad_quote_line:
+    if not missing and not has_bom:
         print()
         print(f"You're ready to start Task {args.task}.")
         return 0
@@ -371,9 +403,12 @@ def main():
     print("Fix the following before starting this task:")
     if has_bom:
         print(f"\n  .env encoding\n    {BOM_HINT}")
-    if bad_quote_line:
-        print(f"\n  .env line {bad_quote_line}\n    {_unterminated_hint(bad_quote_line)}")
+    if bad_quote_line and eaten:
+        print(f"\n  .env line {bad_quote_line}\n"
+              f"    {_unterminated_hint(bad_quote_line, eaten)}")
     for key in missing:
+        if key in eaten:
+            continue  # already explained by the unterminated-quote note above
         print(f"\n  {key}\n    {FIX_HINTS.get(key, 'Add this key to your .env file.')}")
     return 1
 

--- a/index.md
+++ b/index.md
@@ -12,9 +12,14 @@ The following exercises are designed to provide you with a hands-on learning exp
 
 <hr>
 
+{% comment %}
+  Only list pages that aren't drafts. A page opts out by setting `status: 'draft'`
+  in its `lab:` front matter; a page with no `status` field is treated as
+  publishable, so existing exercises are unaffected.
+{% endcomment %}
 {% assign labs = site.pages | where_exp:"page", "page.url contains '/Instructions/Exercises'" %}
 {% for activity in labs  %}
-{% if activity.lab.title %}
+{% if activity.lab.title and activity.lab.status != 'draft' %}
 
 ### [{{ activity.lab.title }}]({{ site.github.url }}{{ activity.url }})
 

--- a/index.md
+++ b/index.md
@@ -14,12 +14,14 @@ The following exercises are designed to provide you with a hands-on learning exp
 
 {% comment %}
   Only list pages that aren't drafts. A page opts out by setting `status: 'draft'`
-  in its `lab:` front matter; a page with no `status` field is treated as
-  publishable, so existing exercises are unaffected.
+  in its `lab:` front matter. The comparison is lower-cased so 'Draft' and 'DRAFT'
+  are excluded too, and `default: ''` means a page with no `status` field is
+  treated as publishable, so existing exercises are unaffected.
 {% endcomment %}
 {% assign labs = site.pages | where_exp:"page", "page.url contains '/Instructions/Exercises'" %}
 {% for activity in labs  %}
-{% if activity.lab.title and activity.lab.status != 'draft' %}
+{% assign lab_status = activity.lab.status | default: '' | downcase %}
+{% if activity.lab.title and lab_status != 'draft' %}
 
 ### [{{ activity.lab.title }}]({{ site.github.url }}{{ activity.url }})
 


### PR DESCRIPTION
## Summary

Consolidates the repo's **5 hands-on labs into 2 larger, modular labs** built on a single fictional scenario, following the house conventions established by the consolidated Lab A/B/C family in `MicrosoftLearning/mslearn-ai-agents`.

**This work is purely additive** to the lab content — no existing lab page or code file is modified. The single intentional exception is a one-line filter in `index.md`, separately authorized by the user (see Flags #1).

- New pages: `Instructions/Exercises/Consolidated/` (12 files)
- New code: `Labfiles/A-extract-information-from-business-content/`, `Labfiles/B-make-extracted-information-searchable/`
- 38 files added across 5 commits

> **Opened as a draft.** See the three flagged decisions and remaining flags at the bottom before merging — in particular, no step has been executed against a live Azure subscription.

---

## Grouping: 5 → 2 labs, and why

I split on the natural seam in the source material — **getting information *out* of content** vs. **making it findable and answerable**. Every source lab landed cleanly on one side of that line, which is what made two labs (rather than one big one or three small ones) the right call. Each lab gets a short Core path plus three self-contained Optional tasks.

| Lab | Section | Task | From | Difficulty |
| --- | --- | --- | --- | --- |
| **A – Extract information from business content** | **Core** | Task 1 – Extract fields from multimodal content | 01 | ▰▰▱▱▱ L200 |
| | *Optional* | Task 2 – Build an analyzer with the Python SDK | 02 | ▰▰▰▱▱ L300 |
| | *Optional* | Task 3 – Extract invoice data with a prebuilt model | 03 (pt 1) | ▰▰▰▱▱ L300 |
| | *Optional* | Task 4 – Train a custom extraction model | 03 (pt 2) | ▰▰▰▱▱ L300 |
| **B – Make extracted information searchable** | **Core** | Task 1 – Build a knowledge mining index | 04 | ▰▰▱▱▱ L200 |
| | *Optional* | Task 2 – Build a RAG ingestion pipeline | 05 (steps 1–2) | ▰▰▰▱▱ L300 |
| | *Optional* | Task 3 – Answer questions with a RAG agent | 05 (step 3) | ▰▰▰▱▱ L300 |
| | *Optional* | Task 4 – Keep the index fresh with watch mode | 05 (step 4) | ▰▰▰▰▱ L400 |

Two source labs were split rather than mapped 1:1:

- **Lab 03 → two tasks.** Prebuilt vs. custom-trained Document Intelligence are genuinely different workflows with different prerequisites (custom needs storage, a SAS URI, and a training run). Splitting them lets someone do the 25-minute prebuilt task without committing to the 40-minute training task.
- **Lab 05 → three tasks.** "Build the index," "query it," and "keep it fresh" are separable milestones, and the watch-mode task is the natural L400 capstone.

**Pedagogy is unchanged.** This is a repackaging: the technical steps, the fields learners define, the code they write, and the fill-in-the-blanks all match the source exercises. Lab A keeps the source's write-the-code blanks; Lab B keeps the source's review-and-run shape.

### Structure

Each lab follows the reference family's shape:

```
Instructions/Exercises/Consolidated/
  <Letter>-<slug>.md            landing page (difficulty meter + "Lab at a glance")
  <Letter>0-getting-started.md  shared setup, run once
  <Letter>1..4-<task>.md        one page per task

Labfiles/<Letter>-<slug>/
  Python/            starter (Lab A has TODO blanks)
  Solution/          complete reference implementation + README
  setup/check_env.py per-task preflight validation
```

Every task page is **standalone-by-default**: a `lab:` frontmatter block, a "What you need" callout that's honest about what does and doesn't carry over, a "Continuing from a previous task?" note for front-to-back learners, and a `**Next:**` footer.

---

## Scenario: Fabrikam Logistics

The sample assets in this repo are immovable binaries that reference **several different** third-party companies — the contact cards, the invoices, and the brochure set don't share a brand, and I can't edit the images, audio, video, or PDFs.

Rather than pretend otherwise, the scenario makes the learner's employer a **single new company, Fabrikam Logistics** (a freight forwarder), that *receives* all this content from third parties: supplier invoices, contact cards collected by reps at trade shows, quarterly review slides, customer voicemails, recorded operations calls, and partner reference documents. That's internally consistent, requires zero binary edits, and means every piece of copy I control uses one brand.

A brand grep across all new files for the prior fictional company names returns **zero hits**.

> **Note for reviewers:** the sample media themselves still visibly carry third-party fictitious names, because they're binaries. That's inherent to the existing assets, not to the new copy.

Concept asides use an **"Ask Rani"** persona (see flagged decisions below).

---

## Currency pass

Source content was treated as authoritative for *what the learner does*, never for *what things are currently called*. Every change below was verified against official Microsoft docs before being applied, and applied consistently across instructions, code, comments, and `.env.example`.

| Old | New | Verified against |
| --- | --- | --- |
| `gpt-4.1` (analyzer schemas, `.env`) | `gpt-5.2` | [Model retirement schedule](https://learn.microsoft.com/azure/foundry/openai/concepts/model-retirement-schedule) — the GPT-4.1 family retires Oct 2026; the [Content Understanding docs](https://learn.microsoft.com/azure/ai-services/content-understanding/overview) explicitly recommend migrating to `gpt-5.2` |
| `"Forms Recognizer"` (console string in `document-analysis.py`) | `"Azure Document Intelligence"` | [Document Intelligence overview](https://learn.microsoft.com/azure/ai-services/document-intelligence/overview) — "Form Recognizer" is a retired name |
| `AzureOpenAI(..., api_version="2024-06-01")` | `OpenAI(base_url=".../openai/v1/")` | [Azure OpenAI v1 API](https://learn.microsoft.com/azure/foundry/openai/api-version-lifecycle) — v1 is GA and removes dated `api-version` pinning |
| `temperature` / `max_tokens` on the chat call | removed | Consequence of the model swap — the GPT-5 reasoning family rejects these parameters |
| unpinned `azure-ai-contentunderstanding` | `==1.1.0` | PyPI (current release) |
| unpinned `python-dotenv` | `==1.2.2` | PyPI (current release) |
| DI Studio at `contentunderstanding.…/documentintelligence/studio` | `https://documentintelligence.ai.azure.com/studio` | Document Intelligence docs (the source lab was internally inconsistent, using both) |
| Python 3.8/3.9 era guidance | Python 3.11+ (tested on 3.13) | [Azure SDK for Python overview](https://learn.microsoft.com/azure/developer/python/sdk/azure-sdk-overview) — 3.9 or later |

**Confirmed already current, deliberately left alone:** `text-embedding-3-large` (GA, retires Feb 2028), `prebuilt-invoice` / `prebuilt-read` / `prebuilt-layout`, `azure-ai-documentintelligence==1.0.2`, `azure-search-documents==11.6.0`, the "Import data" wizard name, "Azure AI Search", and Microsoft Foundry portal/resource/project terminology.

**Deliberately *not* changed — flagged instead of silently reworked:** the labs still authenticate with **resource keys**. Microsoft now recommends Microsoft Entra ID with `DefaultAzureCredential`, but switching would change the actual procedure (role assignments, `az login` steps), which is out of scope for a repackaging. Instead, each lab adds a note pointing at [Foundry Tools authentication](https://learn.microsoft.com/azure/ai-services/authentication) and [AI Search RBAC](https://learn.microsoft.com/azure/search/search-security-rbac).

### Source bugs fixed while porting

- `search-app.py` — nested same-type quotes in an f-string (`f"...{document["title"]}"`), which only parses on Python 3.12+.
- `ingest-pipeline.py` — non-ASCII em-dashes in `print()` output, which can fail on a Windows console.

---

## Validation gate

| Check | Result |
| --- | --- |
| `py_compile` on every new `.py` (starter + solution) | **14/14 pass** |
| ASCII scan of runtime strings in all `.py` | **0 violations** |
| JSON files parse | **2/2 valid** |
| SDK symbol resolution in a real venv | **pass** — `begin_create_analyzer`, `begin_analyze_binary`, `begin_analyze_document`, `upload_documents`, `search`, `create_or_update_index` all resolve against the pinned versions |
| `check_env.py --task N` | **pass** — all 4 tasks × both labs, in both the missing-values and fully-satisfied states; `--help` clean with no network calls; invalid task number rejected; **and re-verified on a clean interpreter with no `python-dotenv` installed** |
| Brand consistency grep | **0 hits** for any prior fictional company |
| Stale-term grep | **0 hits** for retired names, deprecated models, dated api-versions |
| Internal `.md` links | **0 broken** across all 12 pages |
| Media references (`../media/…`, incl. `<video>`/`<track>`) | **0 missing** — all 18 local refs resolved from each page's own on-disk folder; also checked for wrong-depth `../../media`, capital-`Media` case mismatches (Linux/Pages is case-sensitive), and exact filename casing. See note below. |
| Difficulty meters | **pass** — 1 header meter + 4 glance rows per landing; **0** on task pages (they carry `level:` in frontmatter instead) |
| Instruction snippets vs. `Solution/` files | **byte-identical** for all pasted blocks |
| Relative path resolution on disk | **pass** — `parents[3]`/`parents[4]` media lookups and the training-forms path all resolve |
| Staging hygiene | **clean** — no `__pycache__`, `.pyc`, venvs, or real `.env` files |

**Not runnable in-repo, and validated the way the profile prescribes:** Task A1 is portal-only, and every Azure-calling step needs a live subscription. These were validated by `py_compile` + live SDK symbol resolution + fidelity to the source exercises and official quickstarts — not by execution.

### Media path depth audit

Consolidated pages sit one level deeper than the source exercises, so any `../media/...` reference copied from a source page can silently break. This repo is the highest-risk case, because the invoices, contact cards, and call/meeting recordings are deliberately **referenced by relative path rather than duplicated** as binaries.

Audited explicitly. On disk, `Instructions/Exercises/media/` and `Instructions/Exercises/Consolidated/` are **siblings**, so `../media/...` is the correct prefix at this depth (not `../../media/...`). All **18** local image, `<video src>`, and `<track src>` references were resolved from each page's own folder: **0 broken**. Also confirmed: no wrong-depth `../../media` refs, and no capital-`Media` paths.

**Casing re-verified against git's index, not the filesystem.** This repo has `core.ignorecase = true`, so a `Test-Path`-style existence check is vacuous for casing — it would pass on Windows and still 404 on Linux/GitHub Pages. Every one of the 18 references was therefore re-resolved to a repo-root path and matched against the exact-case paths in `git ls-files`: **18/18 exact-case matches, 0 failures.** The media directory is `Instructions/Exercises/media` (lowercase) in the index, and no reference uses any other casing.

The `Ask Rani` concept-block CSS carries **no inherited asset URL** — the reference family's `url("../Media/anton-avatar.png")` was dropped when the persona was introduced, since no equivalent asset exists here. A grep for `url(` and `avatar` across all 12 pages returns nothing. This matters because the reference repo genuinely uses `Instructions/Media` with a capital M, so any inherited path would have been a live casing hazard here.

The `check_env.py` path audit was likewise run across **all file types**, not just `.md`/`.py` — all 17 references use the correct `../setup/` form. This repo ships no `write_env.ps1`/`write_env.sh` azd hooks (no `azd`/`infra` — see flagged decisions), so that location class doesn't exist here. The `FIX_HINTS` strings that `check_env.py` prints on its failure path were checked too: they reference only portal locations and `.env` key names, never a command or path.

### The `check_env` path fix

A review pass caught a **learner-blocking bug inherited from the reference repo**: the getting-started pages tell learners to open the `Python/` folder as their VS Code workspace, but every preflight command was written as `python setup/check_env.py`, which fails from there — `setup/` is a *sibling* of `Python/`, not a child.

Fixed to `python ../setup/check_env.py` across all 12 instruction pages and both `Solution/README.md` files, plus two `cd` commands (`A4` pointed at a repo-root-relative path; `B4` re-entered a folder the learner was already in), and a step-ordering bug in `A4` where a preflight ran while the terminal was still inside `setup/`.

A follow-up commit (prompted by the parallel `mslearn-ai-vision` session finding the same class of issue) caught **four more occurrences the first pass missed** — the module docstrings in both `setup/check_env.py` files, and the file-tree annotations in both `Solution/README.md` files — plus a subtler **ambiguity**: both READMEs said to run the check "from the `Python` folder", which, in a README that lives in `Solution/`, reads as `Solution/Python/`. From there `../setup/` resolves to `Solution/setup/`, which exists in neither lab. Lab A's README now says the **starter** `Python/` folder and explicitly rules out `Solution/Python/`; Lab B's names its single `Python/` folder and notes it has no `Solution/Python/`. The instruction pages were checked and never send learners to `Solution/Python`, so they were already unambiguous.

Verified afterwards: zero remaining un-prefixed `python setup/check_env.py` strings anywhere in the new files.

### The `python-dotenv` preflight fix

A third issue, surfaced by the parallel `mslearn-ai-studio` session and confirmed here: both `setup/check_env.py` files did a hard top-level `from dotenv import dotenv_values`. But `python-dotenv` only exists inside the lab's `labenv` virtual environment, and the preflight check is explicitly meant to run **before** `pip install -r requirements.txt`. On a clean interpreter a learner got a fatal traceback instead of a readiness report:

```
ModuleNotFoundError: No module named 'dotenv'
```

This was **worst in Lab A**, whose Task 1 is portal-only: that task tells learners they need no code and no `.env`, then offered a command that could only work if they'd already run an install they were never asked to do.

The fallback is a **module-level `_parse_env_file()`** (not buried in the `ImportError` branch), so it can be imported and tested directly even when `python-dotenv` is present. It is verified at **0 divergences from `python-dotenv` 1.2.2** across both labs on: a 27-line / 23-key well-formed corpus; a CRLF corpus with duplicate keys and the `"a\\nb"` double-escape trap; five unterminated-quote shapes; four mixed-quote shapes; and three escape-during-recovery shapes. Coverage includes whole-line and indented comments; plain, double-quoted and single-quoted values; `export KEY=value` (plain and quoted — the key is `KEY`, not `export KEY`); inline comments after unquoted, double-quoted *and* single-quoted values; `EMPTY=`; empty quotes; a bare key with no `=` (dotenv emits `None`); whitespace around `=`; `=` inside a value; `#` inside quotes; all five backslash-escape forms (`\n \r \t \\ \"`); CRLF line endings; duplicate keys (last wins); a URL; and trailing spaces.

Getting there took several rounds of widening the corpus, which found real bugs each time — most of them **false negatives**, where a correctly-set key was reported `MISSING`: quotes retained when a comment followed a quoted value, early termination on `\"`, undecoded escapes, and a skipped bare key. Escapes are decoded in the same single pass that finds the closing quote, so an escaped backslash isn't re-processed (`"a\\nb"` stays a literal `\n`, it does not become a newline).

**Two malformed-file conditions are detected and explained rather than hidden**, because a preflight that disagrees with the runtime is worse than one that simply fails:

- **UTF-8 BOM.** Reading with `utf-8-sig` quietly normalized the BOM away, so the checker reported `[OK]` for a file the app cannot read. Verified against the shipped app code: with a BOM'd `.env`, `load_dotenv()` registers the first key as `"\ufeffFOUNDRY_ENDPOINT"`, so `os.getenv("FOUNDRY_ENDPOINT")` returns `None` and the app fails. Normalizing turned a false negative into a **false positive** — told you're ready, then fail inside the app. Now reported as `[PROBLEM] .env starts with a UTF-8 BOM` with re-save instructions, exiting non-zero even when every key is present.
- **Unterminated quotes.** The parser matches `python-dotenv` exactly, and the check is gated on **measured impact, not presence** — because an unconditionally-fatal check is its own false negative. A key that's *written in the file but absent from the parsed result* was eaten by the malformation, which distinguishes "you never set this" from "you set this and it isn't reaching the app":
  - eats a key the task needs → `[PROBLEM] .env line N: unterminated quote`, **exit 1**, hint names the line and the eaten keys
  - eats nothing the task needs → `[NOTE] .env line N: unterminated quote (nothing this task needs is affected)`, **exit 0**

  A BOM stays unconditionally fatal, since it always corrupts the first setting. When a key is missing for an unrelated reason *and* a harmless stray quote exists, the quote is reported as a `NOTE` and the genuinely missing key drives the failure — so the wrong thing is never blamed.

Establishing dotenv's real behavior for unterminated quotes took measurement, because it's neither "discard the entry" nor "swallow to EOF" — it scans ahead for the matching quote, and only if one is found are the crossed lines consumed:

| `.env` | dotenv keeps |
| --- | --- |
| `UNTERM="oops` / `NEXT=v` / `THIRD=v` | `NEXT`, `THIRD` |
| `UNTERM="oops` / `NEXT=v` / `LATER="c"` / `THIRD=v` | `THIRD` only — `NEXT` and `LATER` swallowed |
| two unterminated lines, no later quotes | both dropped, rest survives |
| `B='unterm` / `C=3` / `D="closes here"` / `E=5` | all but `B` — a `"` does **not** close a `'` |
| `B='unterm` / `C="it's here"` / `D=4` | `A`, `D` — an apostrophe *inside* a double-quoted value **does** close it |
| `B="unterm` / `C=has \" escaped only` / `D=4` | `A`, `D` — the escaped quote closes it when it's the only candidate |
| `B="unterm` / `C=has \" escaped` / `D="real close"` / `E=5` | `A`, `E` — the escaped candidate is **skipped** for the real one |

All match. Recovery scans **escape-aware first and retries raw** only if no escape-aware close exists anywhere — the sole shape that reproduces the last two rows, which pull in opposite directions. Escapes are honoured for *both* quote characters during recovery (measured, not assumed) even though single-quoted *values* are otherwise literal. The last row is the false-positive case: a raw-only scan keeps `D`, so a required key there would be reported present while the app never receives it.

**App-versus-preflight agreement was verified directly**, with a harness asserting the check reports ready *if and only if* the shipped app pattern (`load_dotenv()` + `os.getenv()`) can read every key the task needs: **8 scenarios × 2 interpreters = 16 runs, 0 mismatches.** Scenarios cover an unclosed quote above a needed key (both swallowing and non-swallowing), below every needed key, on the needed key itself, a genuinely absent key, an unreplaced placeholder, and a stray quote combined with a real missing key. Parity holds across **17 corpora** in total. Identical results whether real dotenv or the fallback does the reading.

Verified on a **purpose-built dotenv-free venv** (absence confirmed via a failing `import dotenv` and `pip list` — the system Python here *does* have dotenv, which is what masked the bug originally): all 4 tasks × both labs work in both the missing-values and satisfied states, `--help` exits 0 with no traceback (validation gate item 5, which the original bug also violated since the import failed before `argparse` ran), and placeholder rejection still works. Re-verified with dotenv present to confirm no regression.

> This bug class was inherited from the reference repo and has been confirmed across the repos in this effort.

---

## Decisions flagged for review (happy to be overruled)

1. **Lab B ships complete code with no `Solution/Python/` split.** The house convention is starter-with-TODOs + matching Solution. But Lab B's source exercises (04, 05) were *review-and-run*: learners read each script and execute it, with no blanks. Adding blanks would have changed the pedagogy, which the consolidation brief forbids. So Lab B's `Python/` is complete and its `Solution/README.md` explains the reasoning and documents how to run each task. Lab A is the write-the-code lab and does have the full starter/Solution split. **If you'd rather have convention consistency than source fidelity here, say so and I'll add blanks to Lab B.**

2. **Invented an "Ask Rani" persona.** The reference family uses "Ask Anton" for its just-in-time concept asides; this repo had no existing persona to inherit. I introduced Rani, a Fabrikam Logistics data engineer, and kept the reference's `<details class="concept">` styling — but dropped the avatar background image, since no equivalent asset exists in this repo. **Open to a different name, or to reusing Anton for cross-repo consistency.**

3. **No `azd` / `infra/` provisioning.** The reference labs ship an optional one-command `azd up` path. These labs provision through the portal instead. I chose not to hand-write Bicep for Foundry + AI Search + Storage that I had no way to deploy or validate from here — untested infra templates seemed worse than none. **Worth adding as a follow-up if someone can validate it against a subscription.**

---

## Flags

1. **~~`index.md` will list all 12 new pages~~ — RESOLVED.** Originally flagged: the GitHub Pages index builds from a Liquid loop over every page under `/Instructions/Exercises` with a `lab.title` key and no `status` filter, so the 12 new pages would have appeared on the published index — including two identically-titled "Getting started" entries and 8 sub-task pages rendered as standalone labs.

   I deliberately did **not** fix this initially, because `index.md` is a shared root file outside this PR's additive scope and the fix was a judgement call. **The user has since decided and authorized it:** filter the loop on `status`, applied consistently across all four repos in this effort.

   Implemented in `7cbc145`, hardened in `dbb7205` to the form all four repos are standardizing on:

   ```liquid
   {% assign lab_status = activity.lab.status | default: '' | downcase %}
   {% if activity.lab.title and lab_status != 'draft' %}
   ```

   `downcase` excludes `Draft`/`DRAFT` too rather than relying on every author using lowercase, and `default: ''` keeps a **missing `status` publishable**, so existing content is unaffected.

   **Verified by rendering the template, not by reasoning about it.** Jekyll isn't available here, so `python-liquid` executes the real loop body from `index.md` against a `site.pages` collection built from the repo's genuine front matter, with a stand-in for Jekyll's `where_exp`. Assertions: exactly the 5 released exercises list, 0 drafts leak, 0 non-drafts are wrongly dropped, 0 duplicate titles. Before/after: **17 entries with a duplicated "Getting started" collapses to 5 with none.** Edge cases pass for missing `status`, `released`, `draft`, `Draft`, and `DRAFT`. This is the one intentional change to a pre-existing file in this PR.

2. **Pre-existing breakage found — reported, not fixed.** A `py_compile` sweep across **every** `.py` in the repo (not just mine) found **2 pre-existing failures on `main`**, both in `Labfiles/02-content-understanding-api/`: `create-analyzer.py` and `read-card.py` each define a function whose body is only a comment, with no statement or `pass`, so they raise `IndentationError` as shipped. A learner running either file before pasting the lab code gets a raw traceback. Filed as a separate issue rather than fixed here, to keep this PR additive. Sweep scope: 23 files checked, 2 failed, both pre-existing; **0 of my 14 new files fail.** (My consolidated starters put `pass` under each `# TODO:`, so they run as shipped.)

3. **Unvalidated major version bumps available.** `azure-search-documents` 12.0.0 and `openai` 3.0.0 are both released, but I pinned **11.6.0** and **1.109.1**. Those are major bumps that could change the `VectorizedQuery` / index-definition / client surfaces this code uses, and I had no way to run them against live Azure. Kept parity with what's known-good and flagged rather than silently diverging.

4. **Portal-only and Azure-calling steps are not validated against a subscription.** Task A1 is entirely browser-based; the SDK tasks need live Foundry, Document Intelligence, and AI Search resources. Everything was checked by `py_compile`, live SDK symbol resolution, and fidelity to the source exercises and official docs — but **no step in either lab has been executed end to end against real Azure resources.** That's the main thing a human reviewer should smoke-test before this leaves draft, particularly the `gpt-5.2` model pin and the Azure OpenAI v1 client change in Lab B.

---

## Suggested review order

1. `Instructions/Exercises/Consolidated/A-extract-information-from-business-content.md` and `B-make-extracted-information-searchable.md` — the two landing pages, for the overall shape and grouping.
2. `A1-extract-fields-from-multimodal-content.md` — the largest Core task, to confirm nothing was lost from source lab 01.
3. `Labfiles/*/Solution/README.md` — the file trees and the flagged Lab B decision.
4. Anything in the Currency table you disagree with.
